### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,1 @@
-language: erlang # wither art thou, Go?
-
-install:
- - hg clone -r go1 https://code.google.com/p/go $HOME/go
- - cd $HOME/go/src && ./make.bash
- - mkdir -p $HOME/src || true
- - mkdir -p $HOME/bin || true
- - mkdir -p $HOME/pkg || true
- - export GOPATH=$HOME
- - export PATH=$PATH:$HOME/go/bin
- - go get -v github.com/robfig/revel
- - ln -s $HOME/builds/robfig/revel $HOME/src/github.com/robfig/revel
-
-script:
- - cd $HOME/src/github.com/robfig/revel && go build -v .
- - cd $HOME/src/github.com/robfig/revel && go test -v .
+language: go


### PR DESCRIPTION
Travis now has first class support for Go projects, see [this blog post](http://about.travis-ci.org/blog/support_for_go_c_and_cpp/).

The tests now run in about half a minute instead of >3 minutes on travis and the output log is much smaller.
