### PR TITLE
Error loading hidden non-template files in views directory

### DIFF
--- a/template.go
+++ b/template.go
@@ -134,6 +134,13 @@ func (loader *TemplateLoader) Refresh() *Error {
 
 			// Walk into directories.
 			if info.IsDir() {
+				if !loader.WatchDir(info) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			if !loader.WatchFile(info.Name()) {
 				return nil
 			}
 
@@ -206,6 +213,16 @@ func (loader *TemplateLoader) Refresh() *Error {
 	// Note: compileError may or may not be set.
 	loader.templateSet = templateSet
 	return loader.compileError
+}
+
+func (loader *TemplateLoader) WatchDir(info os.FileInfo) bool {
+	// Watch all directories, except the ones starting with a dot.
+	return !strings.HasPrefix(info.Name(), ".")
+}
+
+func (loader *TemplateLoader) WatchFile(basename string) bool {
+	// Watch all files, except the ones starting with a dot.
+	return !strings.HasPrefix(basename, ".")
 }
 
 // Parse the line, and description from an error message like:


### PR DESCRIPTION
My editor creates hidden temporary files when editing a file, which causes template compilation errors when reloading a page. Maybe we should prevent certain files from being loaded when scanning the templates directory?

Ignoring template files with compilation errors is not an option, since you'll want to know when you've made a typo. I'd suggest ignoring hidden files and directories (in my case these are all names starting with a dot).

I thought I'd ask for some input before creating a pull request, what do you think?
