### PR TITLE
Hacky way to expose the port to the command line

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"github.com/robfig/goconfig/config"
 	"github.com/robfig/revel"
 	"github.com/robfig/revel/harness"
 	"log"
 )
 
 var cmdRun = &Command{
-	UsageLine: "run [import path] [run mode]",
+	UsageLine: "run [import path] [run mode] [port]",
 	Short:     "run a Revel application",
 	Long: `
 Run the Revel web application named by the given import path.
@@ -20,7 +19,12 @@ For example, to run the chat room sample application:
 The run mode is used to select which set of app.conf configuration should
 apply and may be used to determine logic in the application itself.
 
-Run mode defaults to "dev".`,
+Run mode defaults to "dev".
+
+You can set a port as an optional third parameter.  For example:
+
+    revel run github.com/robfig/revel/samples/chat prod 8080`,
+
 }
 
 func init() {
@@ -42,7 +46,7 @@ func runApp(args []string) {
 
 	if len(args) == 3 {
 		// change http.port config
-		rev.Config.AddOption(config.DEFAULT_SECTION, "http.port", args[2])
+		rev.Config.AddOption(mode, "http.port", args[2])
 	}
 
 	log.Printf("Running %s (%s) in %s mode\n", rev.AppName, rev.ImportPath, mode)


### PR DESCRIPTION
This allows the port to be set from the command line.  For running on Heroku we need to be able to set the port programmatically.

There might be better ways to do this so feel free to tell me this is wrong and I should do it in some other way.  Also, I'm new to Go so this code might be horrible.  :)

BTW: I've created a Revel Buildpack for Heroku:
https://github.com/jamesward/heroku-buildpack-go-revel
Demo app and instructions:
https://github.com/jamesward/hellorevel
