### PR TITLE
Patched sample for testing on remote hosts

### DIFF
--- a/samples/chat/app/views/WebSocket/Room.html
+++ b/samples/chat/app/views/WebSocket/Room.html
@@ -49,7 +49,7 @@
 <script type="text/javascript">
 
   // Create a socket
-  var socket = new WebSocket('ws://127.0.0.1:9000/websocket/room/socket?user={{.user}}')
+  var socket = new WebSocket('ws://'+window.location.host+'/websocket/room/socket?user={{.user}}')
 
   // Display a message
   var display = function(event) {


### PR DESCRIPTION
Quick fix for using sample chat app on hosts other than 127.0.0.1.

Uses window.location.host to determine where to open websocket.
