### PR TITLE
Check for nil more carefully for interceptor values

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -106,7 +106,7 @@ func (c *Controller) Invoke(appControllerPtr reflect.Value, method reflect.Value
 
 	plugins.AfterRequest(c)
 
-	if resultValue.IsNil() {
+	if resultValue.Kind() == reflect.Interface && resultValue.IsNil() {
 		return
 	}
 	result := resultValue.Interface().(Result)


### PR DESCRIPTION
This came up when invoking c.RenderError in an intercepted method.
