### PR TITLE
Additional steps to get sqlite3 installed on ubuntu

### DIFF
--- a/samples/booking.md
+++ b/samples/booking.md
@@ -44,7 +44,7 @@ C library.
 >	`brew install pkgconfig sqlite3`
 
 ### To install (Ubuntu):
->       `sudo apt-get install sqlite3 libsqlite3-dev
+>       `sudo apt-get install sqlite3 libsqlite3-dev`
 
 Once you have SQLite installed, it should be possible to run the booking app as
 usual:


### PR DESCRIPTION
I came across a cryptic error message while trying to get the sample booking app running because I was missing the sqllite3 dev libraries in ubuntu. This might be obvious for devs familiar with sqlite3, but my background is mysql and mongo. 

Excerpt of the error below;

```
go get github.com/mattn/go-sqlite3
# pkg-config --cflags sqlite3
Package sqlite3 was not found in the pkg-config search path.
Perhaps you should add the directory containing `sqlite3.pc'
to the PKG_CONFIG_PATH environment variable
No package 'sqlite3' found
exit status 1
```
