### PR TITLE
Fixed an injection vulnerability in session management.

### DIFF
--- a/session.go
+++ b/session.go
@@ -40,11 +40,8 @@ func (p SessionPlugin) AfterRequest(c *Controller) {
 	// Store the session (and sign it).
 	var sessionValue string
 	for key, value := range c.Session {
-		if strings.Contains(key, ":") {
-			panic("Session keys may not have colons")
-		}
-		if strings.Contains(key, "\x00") {
-			panic("Session keys may not have null bytes")
+		if strings.ContainsAny(key, ":\x00") {
+			panic("Session keys may not have colons or null bytes")
 		}
 		if strings.Contains(value, "\x00") {
 			panic("Session values may not have null bytes")


### PR DESCRIPTION
If any session key or value contains a null byte, then the part after
the null is parsed as a separate key/value pair. This fixes it for now
by disallowing null bytes; long term, it may be safer (and almost
certainly smaller) to precede the fields with a length.
