### PR TITLE
Introduce the Session to test suites.

### DIFF
--- a/session.go
+++ b/session.go
@@ -30,16 +30,10 @@ func (s Session) Id() string {
 	return s[SESSION_ID_KEY]
 }
 
-type SessionPlugin struct{ EmptyPlugin }
-
-func (p SessionPlugin) BeforeRequest(c *Controller) {
-	c.Session = restoreSession(c.Request.Request)
-}
-
-func (p SessionPlugin) AfterRequest(c *Controller) {
-	// Store the session (and sign it).
+// Returns an http.Cookie containing the signed session.
+func (s Session) cookie() *http.Cookie {
 	var sessionValue string
-	for key, value := range c.Session {
+	for key, value := range s {
 		if strings.ContainsAny(key, ":\x00") {
 			panic("Session keys may not have colons or null bytes")
 		}
@@ -48,12 +42,48 @@ func (p SessionPlugin) AfterRequest(c *Controller) {
 		}
 		sessionValue += "\x00" + key + ":" + value + "\x00"
 	}
+
 	sessionData := url.QueryEscape(sessionValue)
-	c.SetCookie(&http.Cookie{
+	return &http.Cookie{
 		Name:  CookiePrefix + "_SESSION",
 		Value: Sign(sessionData) + "-" + sessionData,
 		Path:  "/",
+	}
+}
+
+// Returns a Session pulled from signed cookie.
+func getSessionFromCookie(cookie *http.Cookie) Session {
+	session := make(Session)
+
+	// Separate the data from the signature.
+	hyphen := strings.Index(cookie.Value, "-")
+	if hyphen == -1 || hyphen >= len(cookie.Value)-1 {
+		return session
+	}
+	sig, data := cookie.Value[:hyphen], cookie.Value[hyphen+1:]
+
+	// Verify the signature.
+	if Sign(data) != sig {
+		INFO.Println("Session cookie signature failed")
+		return session
+	}
+
+	ParseKeyValueCookie(data, func(key, val string) {
+		session[key] = val
 	})
+
+	return session
+}
+
+type SessionPlugin struct{ EmptyPlugin }
+
+func (p SessionPlugin) BeforeRequest(c *Controller) {
+	c.Session = restoreSession(c.Request.Request)
+}
+
+func (p SessionPlugin) AfterRequest(c *Controller) {
+	// Store the session (and sign it).
+	c.SetCookie(c.Session.cookie())
 }
 
 func restoreSession(req *http.Request) Session {
@@ -63,22 +93,5 @@ func restoreSession(req *http.Request) Session {
 		return Session(session)
 	}
 
-	// Separate the data from the signature.
-	hyphen := strings.Index(cookie.Value, "-")
-	if hyphen == -1 || hyphen >= len(cookie.Value)-1 {
-		return Session(session)
-	}
-	sig, data := cookie.Value[:hyphen], cookie.Value[hyphen+1:]
-
-	// Verify the signature.
-	if Sign(data) != sig {
-		INFO.Println("Session cookie signature failed")
-		return Session(session)
-	}
-
-	ParseKeyValueCookie(data, func(key, val string) {
-		session[key] = val
-	})
-
-	return Session(session)
+	return getSessionFromCookie(cookie)
 }

--- a/tests.go
+++ b/tests.go
@@ -14,6 +14,7 @@ type TestSuite struct {
 	Client       *http.Client
 	Response     *http.Response
 	ResponseBody []byte
+	Session      Session
 }
 
 var TestSuites []interface{} // Array of structs that embed TestSuite
@@ -21,7 +22,7 @@ var TestSuites []interface{} // Array of structs that embed TestSuite
 // NewTestSuite returns an initialized TestSuite ready for use. It is invoked
 // by the test harness to initialize the embedded field in application tests.
 func NewTestSuite() TestSuite {
-	return TestSuite{Client: &http.Client{}}
+	return TestSuite{Client: &http.Client{}, Session: make(Session)}
 }
 
 // Return the address and port of the server, e.g. "127.0.0.1:8557"
@@ -49,7 +50,7 @@ func (t *TestSuite) Get(path string) {
 	if err != nil {
 		panic(err)
 	}
-	t.MakeRequest(req)
+	t.MakeRequestSession(req)
 }
 
 // Issue a POST request to the given path, sending the given Content-Type and
@@ -60,17 +61,27 @@ func (t *TestSuite) Post(path string, contentType string, reader io.Reader) {
 		panic(err)
 	}
 	req.Header.Set("Content-Type", contentType)
-	t.MakeRequest(req)
+	t.MakeRequestSession(req)
 }
 
 // Issue a POST request to the given path as a form post of the given key and
-// values, and store the result in Request and RequestBody.  
+// values, and store the result in Request and RequestBody.
 func (t *TestSuite) PostForm(path string, data url.Values) {
 	t.Post(path, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
 }
 
 // Issue any request and read the response. If successful, the caller may
-// examine the Response and ResponseBody properties.
+// examine the Response and ResponseBody properties. Session data will be
+// added to the request cookies for you.
+func (t *TestSuite) MakeRequestSession(req *http.Request) {
+	req.AddCookie(t.Session.cookie())
+
+	t.MakeRequest(req)
+}
+
+// Issue any request and read the response. If successful, the caller may
+// examine the Response and ResponseBody properties. You will need to
+// manage session / cookie data manually
 func (t *TestSuite) MakeRequest(req *http.Request) {
 	var err error
 	if t.Response, err = t.Client.Do(req); err != nil {
@@ -79,6 +90,8 @@ func (t *TestSuite) MakeRequest(req *http.Request) {
 	if t.ResponseBody, err = ioutil.ReadAll(t.Response.Body); err != nil {
 		panic(err)
 	}
+
+	t.Session = restoreSession(req)
 }
 
 // Create a websocket connection to the given path and return the connection


### PR DESCRIPTION
I've implemented Session into the TestSuite so that you can set values on t.Session as you would with c.Session in your controllers, then any calls to t.Get(), t.Post(), t.PostForm() and a new method called t.MakeRequestSession() which all pass the session cookie along with every request. All requests will restore t.Session from a cookie found in the response.

I apologize for the missing tests, I did start working on tests, but it appears that is going to be quite a bit more involved being the way this runs through the testrunner, and it assumes an app is running because it hooks all kinds of values that are setup by the app and plugins etc. I figured i'd send the pull request anyway in case it's a quick minor change that wants to be pulled in.

I definitely think we'll need to come up with a way of making TestSuite testable itself though, if the test coverage is to improve over time in the app. I may try to investigate this a little when I have more time to do a deep dive on how the test runner, harness and bootstrap process is working under the covers.
