### PR TITLE
Add GOPATH to the list of directories that is monitored for changes.

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -139,7 +139,7 @@ func (h *Harness) WatchFile(filename string) bool {
 // server, which it runs and rebuilds as necessary.
 func (h *Harness) Run() {
 	var paths []string
-	if revel.Config.BoolDefault("watch.gopath", true) {
+	if revel.Config.BoolDefault("watch.gopath", false) {
 		gopaths := filepath.SplitList(build.Default.GOPATH)
 		paths = append(paths, gopaths...)
 	}


### PR DESCRIPTION
I find very useful to have the application also automatically recompiled when modifying external libraries located in GOPATH. The following trivial change does just that (the new config option 'watch.gopath' allows to disable this behaviour).
