### PR TITLE
Fixed static resources to work with newest version of revel. For Chat Sample

### DIFF
--- a/samples/chat/conf/routes
+++ b/samples/chat/conf/routes
@@ -25,5 +25,5 @@ GET     /websocket/room                         WebSocket.Room
 WS      /websocket/room/socket                  WebSocket.RoomSocket
 
 # Map static resources from the /app/public folder to the /public path
-GET     /public/*filepath                       Static.Serve("public")
+GET     /public/{<.*>filepath}                  Static.Serve("public")
 


### PR DESCRIPTION
During testing, was unable to server static javascript / css files. changing the static fileserve path to /public/{<.*>filepath} did the trick.
