### PR TITLE
Have Reverse Router skip 404s

### DIFF
--- a/router.go
+++ b/router.go
@@ -320,8 +320,8 @@ func (router *Router) Reverse(action string, argValues map[string]string) *Actio
 	controllerName, methodName := actionSplit[0], actionSplit[1]
 
 	for _, route := range router.Routes {
-		// Skip 404s
-		if route.Action == "404" {
+		// Skip routes without either a ControllerName or MethodName
+		if route.ControllerName == "" || route.MethodName == "" {
 			continue
 		}
 


### PR DESCRIPTION
Adds if statement that will skip over 404 actions when reverse routing. Since 404 action does not have a controller or method, the reverse router would panic. It doesn't make sense to try to reverse route a 404 route either. Fixes #175
