### PR TITLE
embed the http.ResponseWriter into the response struct

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -52,7 +52,7 @@ func (c *Controller) FlashParams() {
 }
 
 func (c *Controller) SetCookie(cookie *http.Cookie) {
-	http.SetCookie(c.Response.Out, cookie)
+	http.SetCookie(c.Response, cookie)
 }
 
 func (c *Controller) RenderError(err error) Result {

--- a/http.go
+++ b/http.go
@@ -22,12 +22,11 @@ type Request struct {
 type Response struct {
 	Status      int
 	ContentType string
-
-	Out http.ResponseWriter
+	http.ResponseWriter
 }
 
 func NewResponse(w http.ResponseWriter) *Response {
-	return &Response{Out: w}
+	return &Response{ResponseWriter: w}
 }
 
 func NewRequest(r *http.Request) *Request {
@@ -42,15 +41,18 @@ func NewRequest(r *http.Request) *Request {
 // Write the header (for now, just the status code).
 // The status may be set directly by the application (c.Response.Status = 501).
 // if it isn't, then fall back to the provided status code.
-func (resp *Response) WriteHeader(defaultStatusCode int, defaultContentType string) {
+func (resp *Response) SetStatus(defaultStatusCode int) {
 	if resp.Status == 0 {
 		resp.Status = defaultStatusCode
 	}
+	resp.WriteHeader(resp.Status)
+}
+
+func (resp *Response) SetContentType(defaultContentType string) {
 	if resp.ContentType == "" {
 		resp.ContentType = defaultContentType
 	}
-	resp.Out.Header().Set("Content-Type", resp.ContentType)
-	resp.Out.WriteHeader(resp.Status)
+	resp.Header().Set("Content-Type", resp.ContentType)
 }
 
 // Get the content type.

--- a/panic.go
+++ b/panic.go
@@ -21,8 +21,8 @@ func handleInvocationPanic(c *Controller, err interface{}) {
 	error := NewErrorFromPanic(err)
 	if error == nil {
 		ERROR.Print(err, "\n", string(debug.Stack()))
-		c.Response.Out.WriteHeader(500)
-		c.Response.Out.Write(debug.Stack())
+		c.Response.WriteHeader(500)
+		c.Response.Write(debug.Stack())
 		return
 	}
 

--- a/samples/booking/app/init.go
+++ b/samples/booking/app/init.go
@@ -21,9 +21,9 @@ func init() {
 
 var HeaderFilter = func(c *revel.Controller, fc []revel.Filter) {
 	// Add some common security headers
-	c.Response.Out.Header().Add("X-Frame-Options", "SAMEORIGIN")
-	c.Response.Out.Header().Add("X-XSS-Protection", "1; mode=block")
-	c.Response.Out.Header().Add("X-Content-Type-Options", "nosniff")
+	c.Response.Header().Add("X-Frame-Options", "SAMEORIGIN")
+	c.Response.Header().Add("X-XSS-Protection", "1; mode=block")
+	c.Response.Header().Add("X-Content-Type-Options", "nosniff")
 
 	fc[0](c, fc[1:]) // Execute the next filter stage.
 }


### PR DESCRIPTION
this removes the need to write resp.Out.Header() and instead can be resp.Header(). Could cause breaking changes in user code.

The http.WriterHeader func has been renamed to WriteStatusCode to avoid a conflict with http.ResponseWriter.WriteHeader
