### PR TITLE
Add Slug Template Function

### DIFF
--- a/template.go
+++ b/template.go
@@ -36,6 +36,9 @@ type Template interface {
 	Render(wr io.Writer, arg interface{}) error
 }
 
+var invalidSlugPattern = regexp.MustCompile(`[^a-z0-9 _-]`)
+var whiteSpacePattern = regexp.MustCompile(`\s+`)
+
 var (
 	// The functions available for use in the templates.
 	TemplateFuncs = map[string]interface{}{
@@ -148,12 +151,11 @@ var (
 		"datetime": func(date time.Time) string {
 			return date.Format(DateTimeFormat)
 		},
-		"stub": func(text string) string {
+		"slug": func(text string) string {
 			separator := "-"
 			text = strings.ToLower(text)
-			text = regexp.MustCompile("&.+?;").ReplaceAllString(text, "")
-			text = regexp.MustCompile("[^a-z0-9 _-]").ReplaceAllString(text, "")
-			text = regexp.MustCompile("\\s+").ReplaceAllString(text, separator)
+			text = invalidSlugPattern.ReplaceAllString(text, "")
+			text = whiteSpacePattern.ReplaceAllString(text, separator)
 			text = strings.Trim(text, separator)
 			return text
 		},


### PR DESCRIPTION
This adds a slug template function. It allows you to make url slugs for articles, posts, etc

www.example.com/articles/12/slug-title-goes-here

The function currently doesn't support any non-ascii characters. One possibility is to map accented characters to their non-accented ascii character. E.g. Ä => A

I'm not sure whether the function should be available outside of templates.
