### PR TITLE
[RETARGET] Array support by Config.

### DIFF
--- a/config.go
+++ b/config.go
@@ -111,6 +111,29 @@ func (c *MergedConfig) Options(prefix string) []string {
 	return options
 }
 
+func (c *MergedConfig) Array(prefix string) interface{} {
+	var result interface{} = make(map[string]interface{})
+
+	for _, option := range c.Options(prefix) {
+		current := result
+
+		names := strings.Split(option, ".")
+		for k, name := range names[1:] { // We don't need the prefix in the result.
+			if _, ok := current.(map[string]interface{})[name]; !ok {
+				if k == (len(names) - 2) {
+					value, _ := c.String(option)
+					current.(map[string]interface{})[name] = value
+				} else {
+					current.(map[string]interface{})[name] = make(map[string]interface{})
+				}
+			}
+			current = current.(map[string]interface{})[name]
+		}
+	}
+
+	return result
+}
+
 // Helpers
 
 func stripQuotes(s string) string {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,33 @@
+package revel
+
+import (
+	"github.com/robfig/config"
+	"reflect"
+	"testing"
+)
+
+func TestArray(t *testing.T) {
+	c := config.NewDefault()
+
+	if !c.AddOption(config.DEFAULT_SECTION, "connections.mysql.driver", "mysql_driver") {
+		t.Fatal("Unable to add option.")
+	}
+	if !c.AddOption(config.DEFAULT_SECTION, "connections.pgsql.driver", "pgsql_driver") {
+		t.Fatal("Unable to add option.")
+	}
+
+	cfg := &MergedConfig{c, ""}
+
+	cfg.SetSection(config.DEFAULT_SECTION)
+
+	result := cfg.Array("connections")
+
+	expected := map[string]interface{}{
+		"mysql": map[string]interface{}{"driver": "mysql_driver"},
+		"pgsql": map[string]interface{}{"driver": "pgsql_driver"},
+	}
+
+	if !reflect.DeepEqual(expected, result) {
+		t.Fatal("Expected: ", expected, "Got: ", result)
+	}
+}

--- a/modules/connections/app/connections.go
+++ b/modules/connections/app/connections.go
@@ -3,10 +3,10 @@ package connections
 // Multiple named connections configuration module.
 // It support the following config format:
 
-// connection.mysql.drive = mysql
-// connection.mysql.spec = user:pass@localhost:3306
-// connection.pgsql.drive = pgsql
-// connection.pgsql.spec = postgres:pass@dbhost:5432
+// connections.mysql.drive = mysql
+// connections.mysql.spec = user:pass@localhost:3306
+// connections.pgsql.drive = pgsql
+// connections.pgsql.spec = postgres:pass@dbhost:5432
 //
 // Usage:
 // connections.Init()
@@ -14,7 +14,7 @@ package connections
 
 import (
 	"database/sql"
-	"github.com/3d0c/revel"
+	"github.com/robfig/revel"
 )
 
 type Connection struct {

--- a/modules/connections/app/connections.go
+++ b/modules/connections/app/connections.go
@@ -1,0 +1,46 @@
+package connections
+
+// Multiple named connections configuration module.
+// It support the following config format:
+
+// connection.mysql.drive = mysql
+// connection.mysql.spec = user:pass@localhost:3306
+// connection.pgsql.drive = pgsql
+// connection.pgsql.spec = postgres:pass@dbhost:5432
+//
+// Usage:
+// connections.Init()
+// Connections[name].Db
+
+import (
+	"database/sql"
+	"github.com/3d0c/revel"
+)
+
+type Connection struct {
+	Db     *sql.DB
+	Driver string
+	Spec   string
+}
+
+var Connections = map[string]Connection{}
+
+func Init() {
+	connections := revel.Config.Array("connections").(map[string]interface{})
+
+	if len(connections) == 0 {
+		revel.ERROR.Fatal("No `connections` entry found.")
+	}
+
+	for name, options := range connections {
+		driver := options.(map[string]interface{})["driver"].(string)
+		spec := options.(map[string]interface{})["spec"].(string)
+
+		db, err := sql.Open(driver, spec)
+		if err != nil {
+			revel.ERROR.Fatal(err)
+		}
+
+		Connections[name] = Connection{db, driver, spec}
+	}
+}

--- a/modules/connections/app/connections_test.go
+++ b/modules/connections/app/connections_test.go
@@ -1,0 +1,23 @@
+package connections
+
+import (
+	// "database/sql"
+	"github.com/3d0c/revel"
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+	"github.com/robfig/config"
+	"testing"
+)
+
+func TestConnection(t *testing.T) {
+	revel.ConfPaths = append(revel.ConfPaths, "../conf")
+	cfg, err := revel.LoadConfig("sample.conf")
+	if err != nil {
+		t.Fatal("LoadConfig() error:", err)
+	}
+
+	revel.Config = cfg
+	revel.Config.SetSection(config.DEFAULT_SECTION)
+
+	Init()
+}

--- a/modules/connections/app/connections_test.go
+++ b/modules/connections/app/connections_test.go
@@ -1,11 +1,10 @@
 package connections
 
 import (
-	// "database/sql"
-	"github.com/3d0c/revel"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	"github.com/robfig/config"
+	"github.com/robfig/revel"
 	"testing"
 )
 

--- a/modules/connections/conf/sample.conf
+++ b/modules/connections/conf/sample.conf
@@ -1,0 +1,4 @@
+connections.mysql.driver = mysql
+connections.mysql.spec = user:pass@localhost:3306
+connections.pgsql.driver = postgres 
+connections.pgsql.spec = postgres:pass@dbhost:5432


### PR DESCRIPTION
Here is a simple array implementation. It's possible now to map something like this

```
connection.mysql.drive = mysql
connection.mysql.spec = user:pass@localhost:3306
connection.pgsql.drive = pgsql
connection.pgsql.spec = postgres:pass@dbhost:5432
```

into

```
map[
    mysql:map[
        driver : mysql 
        spec  : user:pass@localhost:3306
    ] 
    pgsql:map[
        driver : postgres 
        spec  : postgres:pass@dbhost:5432
    ]
]
```
