### PR TITLE
Make slug function visible outside of Revel package

### DIFF
--- a/template.go
+++ b/template.go
@@ -151,14 +151,7 @@ var (
 		"datetime": func(date time.Time) string {
 			return date.Format(DateTimeFormat)
 		},
-		"slug": func(text string) string {
-			separator := "-"
-			text = strings.ToLower(text)
-			text = invalidSlugPattern.ReplaceAllString(text, "")
-			text = whiteSpacePattern.ReplaceAllString(text, separator)
-			text = strings.Trim(text, separator)
-			return text
-		},
+		"slug": Slug,
 	}
 )
 
@@ -375,4 +368,13 @@ func ReverseUrl(args ...interface{}) (string, error) {
 	}
 
 	return MainRouter.Reverse(args[0].(string), argsByName).Url, nil
+}
+
+func Slug(text string) string {
+	separator := "-"
+	text = strings.ToLower(text)
+	text = invalidSlugPattern.ReplaceAllString(text, "")
+	text = whiteSpacePattern.ReplaceAllString(text, separator)
+	text = strings.Trim(text, separator)
+	return text
 }


### PR DESCRIPTION
Allows calling of slug function from controllers. Useful for redirecting with arguments (in conjunction with ReverseUrl)

---

I think it would be useful to be able to call the slug function outside of templates, for example to redirect.

``` go
func (c Thread) SubmitPost(threadId int64, content string) revel.Result {

    // Validation and database interactions

    url, err := revel.ReverseUrl("Thread.View", id, revel.Slug(thread.Title))
    if err != nil {
        return c.RenderError(err)
    }

    return c.Redirect(url)
}
```
