### PR TITLE
Fix Validation.Error() not modifying Validation.Errors

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -53,10 +53,12 @@ func (v *Validation) ErrorMap() map[string]*ValidationError {
 
 // Add an error to the validation context.
 func (v *Validation) Error(message string, args ...interface{}) *ValidationResult {
-	return (&ValidationResult{
+	result := (&ValidationResult{
 		Ok:    false,
 		Error: &ValidationError{},
 	}).Message(message, args)
+	v.Errors = append(v.Errors, result.Error)
+	return result
 }
 
 // A ValidationResult is returned from every validation method.


### PR DESCRIPTION
Validation.Error() currently doesn't add an error to the Validation.Errors slice, which means that Validation.HasErrors() will not detect the error.

This simple portion of code fixes it.

Related post: https://groups.google.com/forum/?fromgroups#!topic/revel-framework/hw1wfFt4Ys0
