### PR TITLE
Fixed semicolon being appended to filename for BinaryResult(s) using Content-Disposition "attachment"

### DIFF
--- a/results.go
+++ b/results.go
@@ -253,7 +253,7 @@ type BinaryResult struct {
 func (r *BinaryResult) Apply(req *Request, resp *Response) {
 	disposition := string(r.Delivery)
 	if r.Name != "" {
-		disposition += fmt.Sprintf("; filename=%s;", r.Name)
+		disposition += fmt.Sprintf("; filename=%s", r.Name)
 	}
 	resp.Out.Header().Set("Content-Disposition", disposition)
 


### PR DESCRIPTION
While working on a website I noticed that my files had a semicolon being added to the end of them. The headers showed the following: `Content-Disposition: attachment; filename=XXXX.mp3;`

There shouldn't be the trailing semicolon, so this pull request simply removes it. This doesn't appear to break anything when running the main tests:

```
$ go test github.com/robfig/revel
ok      github.com/robfig/revel 0.117s
```

If more tests are needed, I'd be happy to attach them.
