### PR TITLE
Ability to run a specific test suite and method when testing via the command line

### DIFF
--- a/revel/test.go
+++ b/revel/test.go
@@ -231,14 +231,10 @@ func pluralize(num int, singular, plural string) string {
 }
 
 // Filters test suites and individual tests to match
-// the passed command line parameter
+// the parsed command line parameter
 func filterTestSuites(suites []controllers.TestSuiteDesc, suiteArgument string) []controllers.TestSuiteDesc {
-	// Parse optional specific test suite/method argument
 	var suiteName, testName string
 	argArray := strings.Split(suiteArgument, ".")
-	if len(argArray) == 0 {
-		return suites
-	}
 	suiteName = argArray[0]
 	if suiteName == "" {
 		return suites
@@ -247,25 +243,25 @@ func filterTestSuites(suites []controllers.TestSuiteDesc, suiteArgument string) 
 		testName = argArray[1]
 	}
 	for _, suite := range suites {
-		if suite.Name == suiteName {
-			// Run the whole test suite unmodified
-			if testName == "" {
-				return []controllers.TestSuiteDesc{suite}
-			} else {
-				// Only run a particular test in a suite
-				for _, test := range suite.Tests {
-					if test.Name == testName {
-						return []controllers.TestSuiteDesc{
-							controllers.TestSuiteDesc{
-								Name:  suite.Name,
-								Tests: []controllers.TestDesc{test},
-							},
-						}
-					}
-				}
-				errorf("Couldn't find test %s in suite %s", testName, suiteName)
+		if suite.Name != suiteName {
+			continue
+		}
+		if testName == "" {
+			return []controllers.TestSuiteDesc{suite}
+		}
+		// Only run a particular test in a suite
+		for _, test := range suite.Tests {
+			if test.Name != testName {
+				continue
+			}
+			return []controllers.TestSuiteDesc{
+				controllers.TestSuiteDesc{
+					Name:  suite.Name,
+					Tests: []controllers.TestDesc{test},
+				},
 			}
 		}
+		errorf("Couldn't find test %s in suite %s", testName, suiteName)
 	}
 	errorf("Couldn't find test suite %s", suiteName)
 	return nil


### PR DESCRIPTION
I've been writing a lot of unit tests with Revel lately. One thing that was bothering me is when a specific test or suite was failing, I had to re-run the entire thing to see if the status changed. That not only took more time than I wanted, but often if a test was failing it would lock up the database and break the other tests anyway.

When I develop I wanted to continually re-run a specific test or test suite, as [Django allows you to do](https://docs.djangoproject.com/en/dev/topics/testing/overview/):

``` b
# Run just one test case
$ ./manage.py test animals.tests.AnimalTestCase

# Run just one test method
$ ./manage.py test animals.tests.AnimalTestCase.test_animals_can_speak
```

With this pull request, you can. If you agree about this feature, I can modify gh-pages to reflect the new functionality.
