### PR TITLE
Fixing gender reference in pages index

### DIFF
--- a/index.html
+++ b/index.html
@@ -550,8 +550,8 @@ func handleInternal(w http.ResponseWriter, r *http.Request, ws *websocket.Conn) 
             <a href="https://github.com/astaxie/beedb">beedb</a>,
             <a href="https://github.com/gosexy/db">gosexy</a>)
           <li> <b>Pluggable template loader</b> -- Presently only Go templates
-          are supported by Revel (although the developer could use his own
-          library independently).  Providing an interface that makes any
+          are supported by Revel (although the developer could use his or her
+          own library independently).  Providing an interface that makes any
           template language pluggable would be ideal.
         </ul>
       </section>


### PR DESCRIPTION
When I was reading this it confused me because the page had a hardcoded assumption about the gender of the developer.

An aside: a pluggable template architecture sounds great.
