### PR TITLE
Fix call to Message() in Validation.Error()

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -56,7 +56,7 @@ func (v *Validation) Error(message string, args ...interface{}) *ValidationResul
 	result := (&ValidationResult{
 		Ok:    false,
 		Error: &ValidationError{},
-	}).Message(message, args)
+	}).Message(message, args...)
 	v.Errors = append(v.Errors, result.Error)
 	return result
 }


### PR DESCRIPTION
When you call Error() with only one argument, e.g c.Validation.Error("Nope"), printing the error won't display just "Nope", but something like "Nope%!(EXTRA []interface {}=[[]])".

Turns out, forgetting the "..." in the Message() call makes len(args) equals 1 in Message(), hence a useless call to fmt.Sprintf() in Message(), and a very unpleasant display.
