### PR TITLE
Fix wrong markdown syntax causing errors in github pages.

### DIFF
--- a/manual/binding.md
+++ b/manual/binding.md
@@ -49,13 +49,15 @@ To bind a parameter to a data type, use Revel's Binder
 ([godoc](../docs/godoc/binder.html)).  It is integrated with the Params object
 as the following example shows:
 
+{% raw %}
 <pre class="prettyprint lang-go">
 func (c SomeController) Action() revel.Result {
 	var ids []int
-	c.Params.Bind(&ids, "ids")
+	c.Params.Bind(&amp;ids, "ids")
 	...
 }
 </pre>
+{% endraw %}
 
 The following data types are supported out of the box:
 * Ints of all widths

--- a/manual/cache.md
+++ b/manual/cache.md
@@ -64,7 +64,7 @@ import (
 
 func (c App) ShowProduct(id string) revel.Result {
 	var product Product
-	if err := cache.Get("product_"+id, &product); err != nil {
+	if err := cache.Get("product_"+id, &amp;product); err != nil {
 	    product = loadProduct(id)
 	    go cache.Set("product_"+id, product, 30*time.Minute)
 	}
@@ -104,6 +104,6 @@ take advantage of the session's UUID, as shown below:
 cache.Set(c.Session.Id(), products)
 
 // and then in subsequent requests
-err := cache.Get(c.Session.Id(), &products)
+err := cache.Get(c.Session.Id(), &amp;products)
 </pre>
 {% endraw %}


### PR DESCRIPTION
This fixes github page errors of the documentation.

I've pulled this out since the intended cross-compile manual work would take me some time to finish. :)
