### PR TITLE
Make Before and After methods of *AppTest in skeleton

### DIFF
--- a/skeleton/tests/apptest.go
+++ b/skeleton/tests/apptest.go
@@ -6,7 +6,7 @@ type AppTest struct {
 	revel.TestSuite
 }
 
-func (t AppTest) Before() {
+func (t *AppTest) Before() {
 	println("Set up")
 }
 
@@ -16,6 +16,6 @@ func (t AppTest) TestThatIndexPageWorks() {
 	t.AssertContentType("text/html")
 }
 
-func (t AppTest) After() {
+func (t *AppTest) After() {
 	println("Tear down")
 }


### PR DESCRIPTION
The test case generated by `revel new` generates methods for `AppTest`. That means that `Before()` and `After()`  receive new, independent instances of `AppTest`. This PR makes them receive `*AppTest` so you can access values of AppTest's fields After the Test that have been set Before. Note that the test itself still receives a copy of `t`, so the tests stay independent of one another.

``` go

type AppTest struct {
    revel.TestSuite

    foo string        // contrived example, pretend this is a complex thing to setup
}

func (t *AppTest) Before() {
    println("Set up")
    t.foo = "bar"
}

func (t AppTest) Test1() {
    t.foo = "baz"
    t.AssertOk(t.foo == "baz")
}

func (t AppTest) Test2() {
    t.AssertOk(t.foo == "bar")
}

func (t *AppTest) After() {
    t.foo = nil
}
```
