### PR TITLE
Use Twitter's 1.1 API endpoint for tweeting.

### DIFF
--- a/samples/twitter-oauth/app/controllers/app.go
+++ b/samples/twitter-oauth/app/controllers/app.go
@@ -53,7 +53,7 @@ func (c Application) Index() revel.Result {
 
 func (c Application) SetStatus(status string) revel.Result {
 	resp, err := TWITTER.PostForm(
-		"http://api.twitter.com/1/statuses/update.json",
+		"http://api.twitter.com/1.1/statuses/update.json",
 		map[string]string{"status": status},
 		getUser().AccessToken,
 	)


### PR DESCRIPTION
Fixes a crash due to using Twitter's old API when trying to tweet.
