### PR TITLE
Fixed non visible code in the tutorial

### DIFF
--- a/tutorial/firstapp.md
+++ b/tutorial/firstapp.md
@@ -74,6 +74,7 @@ name. Their name and the validation error are kept in the
 
 The provided `flash.html` template will show any errors or flash messages:
 
+{% raw %}
 	{{if .flash.success}}
 	<div class="alert alert-success">
 		{{.flash.success}}
@@ -94,6 +95,7 @@ The provided `flash.html` template will show any errors or flash messages:
 		{{end}}
 	</div>
 	{{end}}
+{% endraw %}
 
 Now when we submit a single letter as our name:
 


### PR DESCRIPTION
The last HTML snippet in [this tutorial page](http://robfig.github.io/revel/tutorial/firstapp.html) has some parts missing because they're being interpreted.
