### PR TITLE
Fix Variable Argument Error in Assertf

### DIFF
--- a/tests.go
+++ b/tests.go
@@ -155,7 +155,7 @@ func (t *TestSuite) Assert(exp bool) {
 
 func (t *TestSuite) Assertf(exp bool, formatStr string, args ...interface{}) {
 	if !exp {
-		panic(fmt.Errorf(formatStr, args))
+		panic(fmt.Errorf(formatStr, args...))
 	}
 }
 


### PR DESCRIPTION
Revel Assertf feeds it's variable arguments to Errorf errornously, causing wrongly formatted string to be printed.
