### PR TITLE
changing 'his' -> 'their'

### DIFF
--- a/index.html
+++ b/index.html
@@ -550,7 +550,7 @@ func handleInternal(w http.ResponseWriter, r *http.Request, ws *websocket.Conn) 
             <a href="https://github.com/astaxie/beedb">beedb</a>,
             <a href="https://github.com/gosexy/db">gosexy</a>)
           <li> <b>Pluggable template loader</b> -- Presently only Go templates
-          are supported by Revel (although the developer could use his own
+          are supported by Revel (although the developer could use their own
           library independently).  Providing an interface that makes any
           template language pluggable would be ideal.
         </ul>


### PR DESCRIPTION
> Thanks. I think that "their" is the correct gender-neutral pronoun in this case :)

Agreed! I changed it to use the more neutral term 'their'.
