### PR TITLE
Fix SSL usage in TestSuite

### DIFF
--- a/tests.go
+++ b/tests.go
@@ -40,9 +40,14 @@ func (t *TestSuite) Host() string {
 	return Server.Addr
 }
 
-// Return the base http URL of the server, e.g. "http://127.0.0.1:8557"
+// Return the base http/https URL of the server, e.g. "http://127.0.0.1:8557".
+// The scheme is set to https if http.ssl is set to true in the configuration file.
 func (t *TestSuite) BaseUrl() string {
-	return "http://" + t.Host()
+	if HttpSsl {
+		return "https://" + t.Host()
+	} else {
+		return "http://" + t.Host()
+	}
 }
 
 // Return the base websocket URL of the server, e.g. "ws://127.0.0.1:8557"


### PR DESCRIPTION
TestSuite.BaseUrl() only works for http, and if you try to use SSL with the most recent commits you have this kind of error:

```
Post http://127.0.0.1:46086/c/a: malformed HTTP response "\x15\x03\x01\x00\x02\x02\x16"
```

This patch fixes it.
Now I have a self-signed certificate issue, oh well...
