### PR TITLE
[RETARGET] Add {{repeat .content .times}} template tag

### DIFF
--- a/template.go
+++ b/template.go
@@ -89,7 +89,10 @@ var (
 			}
 			return template.HTML(html.EscapeString(str) + strings.Repeat("&nbsp;", width-len(str)))
 		},
-
+		// Repeats the given content a given amount of times
+		"repeat": func(content string, times int) template.HTML {
+			return template.HTML(strings.Repeat(content, times))
+		},
 		"errorClass": func(name string, renderArgs map[string]interface{}) template.HTML {
 			errorMap, ok := renderArgs["errors"].(map[string]*ValidationError)
 			if !ok {


### PR DESCRIPTION
Adds a _repeat_ template tag that will repeat a given unescaped content a given
number of times. Works like {{pad}} but with a dynamic content.

Use case:

Let's assume you need to show a tree structure, you may want to do something like this:

`{{repeat "<span class='indent'></span>" .Depth}}`



