### PR TITLE
Add {{include}} template tag

### DIFF
--- a/template.go
+++ b/template.go
@@ -39,7 +39,7 @@ type Template interface {
 
 var invalidSlugPattern = regexp.MustCompile(`[^a-z0-9 _-]`)
 var whiteSpacePattern = regexp.MustCompile(`\s+`)
-var includePattern = regexp.MustCompile(`{{\s*include\s+"(?P<file>\S*)"\s*}}`)
+var includePattern = regexp.MustCompile(`{{\s*include\s+"(?P<file>.*?)"\s*}}`)
 
 var (
 	// The functions available for use in the templates.


### PR DESCRIPTION
#### example:

file "Dashboard/Action.html"

``` html
<div class="container">
{{set $var "foo"}}
{{include "Dashboard/widget_test.html"}}
</div>
```

file "Dashboard/widget_test.html"

``` html
{{$var}}
```

will output:

``` html
<div class="container">
foo
</div>
```

(see code for details)
#### Note:
1. It is inline so almost does not affect performance.
2. Currently it won't check circular reference, so may cause some problems in wrong usage.
