### PR TITLE
[RETARGET] Don't remove the parent folders containing generated code.

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -108,10 +108,37 @@ func Build() (app *App, compileError *revel.Error) {
 
 func cleanSource(dirs ...string) {
 	for _, dir := range dirs {
-		tmpPath := path.Join(revel.AppPath, dir)
-		err := os.RemoveAll(tmpPath)
+		cleanDir(dir)
+	}
+}
+
+func cleanDir(dir string) {
+	revel.INFO.Println("Cleaning dir " + dir)
+	tmpPath := path.Join(revel.AppPath, dir)
+	f, err := os.Open(tmpPath)
+	if err != nil {
+		revel.ERROR.Println("Failed to clean dir:", err)
+	} else {
+		defer f.Close()
+		infos, err := f.Readdir(0)
 		if err != nil {
-			revel.ERROR.Println("Failed to remove dir:", err)
+			revel.ERROR.Println("Failed to clean dir:", err)
+		} else {
+			for _, info := range infos {
+				path := path.Join(tmpPath, info.Name())
+				if info.IsDir() {
+					err := os.RemoveAll(path)
+					if err != nil {
+						revel.ERROR.Println("Failed to remove dir:", err)
+					}
+
+				} else {
+					err := os.Remove(path)
+					if err != nil {
+						revel.ERROR.Println("Failed to remove file:", err)
+					}
+				}
+			}
 		}
 	}
 }
@@ -124,14 +151,11 @@ func genSource(dir, filename, templateSource string, args map[string]interface{}
 		args)
 
 	// Create a fresh dir.
+	cleanSource(dir)
 	tmpPath := path.Join(revel.AppPath, dir)
-	err := os.RemoveAll(tmpPath)
-	if err != nil {
-		revel.ERROR.Println("Failed to remove dir:", err)
-	}
-	err = os.Mkdir(tmpPath, 0777)
-	if err != nil {
-		revel.ERROR.Fatalf("Failed to make tmp directory: %v", err)
+	err := os.Mkdir(tmpPath, 0777)
+	if err != nil && !os.IsExist(err) {
+		revel.ERROR.Fatalf("Failed to make '%v' directory: %v", dir, err)
 	}
 
 	// Create the file


### PR DESCRIPTION
This fails when other apps (ide's) are watching the folders too.

I noticed that the hot-reload removed the temp and routes directories when revel detects it needs to regenerate the code located there. On win8 64bit using  liteide X18.2 that causes a 'access denied' fatal error in revel when revel recreates these directories. Probably because liteide is watching those directories for changes too and locks them somehow.

This patch makes it so revel only removes the contents of these directories, and not the directories themselves for a smooth edit-and-reload experience.

I'm a bit of a pull-request noob, and revel is my very first go experience, so please review this patch with healthy suspicion ;-)
