### PR TITLE
Support for different character tags in the templates

### DIFF
--- a/server.go
+++ b/server.go
@@ -55,7 +55,7 @@ func Run(port int) {
 		address = fmt.Sprintf("%s:%d", address, port)
 	}
 
-	MainTemplateLoader = NewTemplateLoader(TemplatePaths)
+	MainTemplateLoader = NewTemplateLoader(TemplatePaths, ViewsPath, "")
 
 	// The "watch" config variable can turn on and off all watching.
 	// (As a convenient way to control it all together.)

--- a/template.go
+++ b/template.go
@@ -29,6 +29,8 @@ type TemplateLoader struct {
 	paths []string
 	// Map from template name to the path from whence it was loaded.
 	templatePaths map[string]string
+	delims        string
+	viewsPath     string
 }
 
 type Template interface {
@@ -156,10 +158,17 @@ var (
 	}
 )
 
-func NewTemplateLoader(paths []string) *TemplateLoader {
+func NewTemplateLoader(paths []string, viewsPath string, delims string) *TemplateLoader {
 	loader := &TemplateLoader{
-		paths: paths,
+		paths:     paths,
+		viewsPath: viewsPath,
 	}
+	if len(delims) > 0 {
+		loader.delims = delims
+	} else {
+		loader.delims = TemplateDelims
+	}
+
 	return loader
 }
 
@@ -175,8 +184,8 @@ func (loader *TemplateLoader) Refresh() *Error {
 	// Set the template delimiters for the project if present, then split into left
 	// and right delimiters around a space character
 	var splitDelims []string
-	if TemplateDelims != "" {
-		splitDelims = strings.Split(TemplateDelims, " ")
+	if loader.delims != "" {
+		splitDelims = strings.Split(loader.delims, " ")
 		if len(splitDelims) != 2 {
 			log.Fatalln("app.conf: Incorrect format for template.delimiters")
 		}
@@ -242,7 +251,7 @@ func (loader *TemplateLoader) Refresh() *Error {
 					}()
 					templateSet = template.New(templateName).Funcs(TemplateFuncs)
 					// If alternate delimiters set for the project, change them for this set
-					if splitDelims != nil && basePath == ViewsPath {
+					if splitDelims != nil && basePath == loader.viewsPath {
 						templateSet.Delims(splitDelims[0], splitDelims[1])
 					} else {
 						// Reset to default otherwise
@@ -256,7 +265,7 @@ func (loader *TemplateLoader) Refresh() *Error {
 				}
 
 			} else {
-				if splitDelims != nil && basePath == ViewsPath {
+				if splitDelims != nil && basePath == loader.viewsPath {
 					templateSet.Delims(splitDelims[0], splitDelims[1])
 				} else {
 					templateSet.Delims("", "")


### PR DESCRIPTION
Supports various characters tags in the templates according to TemplateLoader.

Example:

mail.html:

``` html
[[define "show"]]
ok
[[end]]
[[template "show"]]
```

invoice.html:

``` html
<<define "invoice">>
ok
<<end>>
<<template "invoice">>
```

app.go:

``` go
func (c App) Mail() r.Result {
    tl := revel.NewTemplateLoader([]string{"/project/name/views/mail"}, "/project/name/views/mail", "[[ ]]")
    tl.Refresh()
    tpl, err := tl.Template("mail.html")
    if err != nil {
        return c.RenderError(err)
    }
    return &revel.RenderTemplateResult{
        Template:   tpl,
        RenderArgs: c.RenderArgs,
    }
}

func (c App) Invoice() r.Result {
    tl := revel.NewTemplateLoader([]string{"/project/name/views/invoice"}, "/project/name/views/invoice", "<< >>")
    tl.Refresh()
    tpl, err := tl.Template("invoice.html")
    if err != nil {
        return c.RenderError(err)
    }
    return &revel.RenderTemplateResult{
        Template:   tpl,
        RenderArgs: c.RenderArgs,
    }
}
```
