### PR TITLE
Allow session only expiration

### DIFF
--- a/session.go
+++ b/session.go
@@ -90,7 +90,7 @@ func sessionTimeoutExpiredOrMissing(session Session) bool {
 		return false
 	} else if expInt, _ := strconv.Atoi(exp); int64(expInt) < time.Now().Unix() {
 		return true
-	} 
+	}
 	return false
 }
 


### PR DESCRIPTION
Now it's possible to set session.expires=0 in config and the session will expire when the browser is closed.

This seems to work for me, but I might have missed something.
