### PR TITLE
Flash arrays as comma-separated string

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -48,7 +48,7 @@ func NewController(req *Request, resp *Response) *Controller {
 
 func (c *Controller) FlashParams() {
 	for key, vals := range c.Params.Values {
-		c.Flash.Out[key] = vals[0]
+		c.Flash.Out[key] = strings.Join(vals, ",")
 	}
 }
 


### PR DESCRIPTION
Along with Field.FlashArray() it solves the issue #191
