### PR TITLE
Fix timing issue with testrunner webpage.

### DIFF
--- a/modules/testrunner/app/views/TestRunner/Index.html
+++ b/modules/testrunner/app/views/TestRunner/Index.html
@@ -46,8 +46,8 @@ var running = 0;
 
 $("button[test]").click(function() {
 	var button = $(this).addClass("disabled").text("Running");
-	runTest(button);
 	running += 1;
+	runTest(button);
 });
 
 $("button[all-tests]").click(function() {


### PR DESCRIPTION
Move running += 1 up before the call to runTest(button). runTest(button) is async. If the ajax call finishes before running can be incremented (and there is only one test) then running will go negative. When this happens, the run all tests button will be permanently disabled until the page is refreshed.
