### PR TITLE
Add whitespaces reminder about 2 parameters version of Static.Serve

### DIFF
--- a/manual/routing.md
+++ b/manual/routing.md
@@ -97,7 +97,10 @@ The corresponding action would have this signature:
 ## Static Serving
 
 	GET    /public/*filepath            Static.Serve("public")
-	GET    /favicon.ico                 Static.Serve("public", "img/favicon.png")
+	GET    /favicon.ico                 Static.Serve("public","img/favicon.png")
+	
+For the 2 parameters version of Static.Serve, blank spaces are not allowed between
+**"** and **,** due to how encoding/csv works.
 
 For serving directories of static assets, Revel provides the **static** module,
 which contains a single


### PR DESCRIPTION
Use of encoding/csv in parsing of the routes file poses limit to the format of parameters passed to Static.Serve,
i.e. spaces between " and , are not insignificant in the parsing of csv values.

Adding spaces between " and , will result in error: bare " in non-quoted-field from encoding/csv.

http://golang.org/pkg/encoding/csv/
