### PR TITLE
Add support for loading templates in text/template using their original case

### DIFF
--- a/template.go
+++ b/template.go
@@ -207,7 +207,6 @@ func (loader *TemplateLoader) Refresh() *Error {
 			}
 
 			var fileStr string
-			var fileBytes []byte
 
 			// addTemplate allows the same template to be added multiple
 			// times with different template names.
@@ -224,8 +223,8 @@ func (loader *TemplateLoader) Refresh() *Error {
 				loader.templatePaths[templateName] = path
 
 				// Load the file if we haven't already
-				if fileBytes == nil {
-					fileBytes, err = ioutil.ReadFile(path)
+				if fileStr == "" {
+					fileBytes, err := ioutil.ReadFile(path)
 					if err != nil {
 						ERROR.Println("Failed reading file:", path)
 						return nil


### PR DESCRIPTION
As per the discussion in #385, #370 broke the ability to use a views' original name inside text/template templates by forcing all the template names to be lowercased. This is a quick fix to support both formats. It just wraps the template adding functionality and calls it once for the original name and one for the lower cased name. 
