### PR TITLE
Use absolute path in -srcPath flag

### DIFF
--- a/revel/package_run.sh.template
+++ b/revel/package_run.sh.template
@@ -1,4 +1,4 @@
 #!/bin/sh
-SCRIPTPATH=`dirname "$0"`
+SCRIPTPATH=$(cd "$(dirname "$0")"; pwd)
 chmod u+x "$SCRIPTPATH/{{.BinName}}"
 "$SCRIPTPATH/{{.BinName}}" -importPath {{.ImportPath}} -srcPath "$SCRIPTPATH/src" -runMode prod


### PR DESCRIPTION
Using ./src causes modules to show wrong paths when serving static files. The windows version uses the full srcPath and is not affected.
