### PR TITLE
Define a REVEL_APP_VERSION variable when building

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
 	"text/template"
 )
 
@@ -66,7 +67,11 @@ func Build() (app *App, compileError *revel.Error) {
 
 	gotten := make(map[string]struct{})
 	for {
+		appVersion := getAppVersion()
+		versionLinkerFlags := fmt.Sprintf("-X %s/app.REVEL_APP_VERSION \"%s\"", revel.ImportPath, appVersion)
+
 		buildCmd := exec.Command(goPath, "build",
+			"-ldflags", versionLinkerFlags,
 			"-tags", buildTags,
 			"-o", binName, path.Join(revel.ImportPath, "app", "tmp"))
 		revel.TRACE.Println("Exec:", buildCmd.Args)
@@ -104,6 +109,33 @@ func Build() (app *App, compileError *revel.Error) {
 	}
 	revel.ERROR.Fatalf("Not reachable")
 	return nil, nil
+}
+
+// Try to define a version string for the compiled app
+// The following is tried (first match returns):
+// - Read a version explicitly specified in the REVEL_APP_VERSION environment
+//   variable
+// - Read the output of "git describe" if the source is in a git repository
+// If no version can be determined, an empty string is returned.
+func getAppVersion() string {
+	if version := os.Getenv("REVEL_APP_VERSION"); version != "" {
+		return version
+	}
+
+	if gitPath, err := exec.LookPath("git"); err == nil {
+		gitCmd := exec.Command(gitPath, "describe", "--always", "--dirty")
+		revel.TRACE.Println("Exec:", gitCmd.Args)
+		output, err := gitCmd.Output()
+
+		if err != nil {
+			revel.WARN.Println("Cannot determine git repository version:", err)
+			return ""
+		}
+
+		return "git-" + strings.TrimSpace(string(output))
+	}
+
+	return ""
 }
 
 func cleanSource(dirs ...string) {


### PR DESCRIPTION
The contents of the variable are determined from the environment
variable of the same name, or from the output of "git describe" if the
environment variable is unset, and if the source is in a git repository.
The variable is defined in the "<ImportPath>/app" module.

I use that to embed the git hash from which my app was compiled
inside the binary, without having to resort to additional Makefile tricks.

If that pull request is accepted, I'll gladly send another one to update the documentation on the website.
