### PR TITLE
add irc link

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,9 +149,10 @@ title: The Revel Web Framework for Go
         </p>
         <p style="font-weight:bold;">
           Join our <a href="https://groups.google.com/forum/#!forum/revel-framework">Google Group</a>
-          to take part in the design and development, or
-          <a href="https://groups.google.com/group/revel-framework-announce">our
-            announcement list</a> to only be notified for new releases.
+          to take part in the design and development, or in IRC at 
+          <a href="http://webchat.freenode.net/?channels=revel&amp;uio=d4">Freenode #revel</a>.
+          You may join <a href="https://groups.google.com/group/revel-framework-announce">our
+          announcement list</a> to only be notified for new releases.
         </p>
         <p>
           <a href="https://twitter.com/revelframework" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @revelframework</a>


### PR DESCRIPTION
Adds a link to the new Freenode #revel channel. Discussed here: https://groups.google.com/forum/#!topic/revel-framework/t9AsnD5T2gg
