### PR TITLE
Importing module routes under the parent path

### DIFF
--- a/fakeapp_test.go
+++ b/fakeapp_test.go
@@ -71,7 +71,7 @@ func startFakeBookingApp() {
 
 	MainRouter = NewRouter("")
 	routesFile, _ := ioutil.ReadFile(filepath.Join(BasePath, "conf", "routes"))
-	MainRouter.Routes, _ = parseRoutes("", string(routesFile), false)
+	MainRouter.Routes, _ = parseRoutes("", "", string(routesFile), false)
 	MainRouter.updateTree()
 	MainTemplateLoader = NewTemplateLoader([]string{ViewsPath, path.Join(RevelPath, "templates")})
 	MainTemplateLoader.Refresh()

--- a/router.go
+++ b/router.go
@@ -131,7 +131,7 @@ func (router *Router) Route(req *http.Request) *RouteMatch {
 // Refresh re-reads the routes file and re-calculates the routing table.
 // Returns an error if a specified action could not be found.
 func (router *Router) Refresh() (err *Error) {
-	router.Routes, err = parseRoutesFile(router.path, true)
+	router.Routes, err = parseRoutesFile(router.path, "", true)
 	if err != nil {
 		return
 	}
@@ -158,7 +158,7 @@ func (router *Router) updateTree() *Error {
 }
 
 // parseRoutesFile reads the given routes file and returns the contained routes.
-func parseRoutesFile(routesPath string, validate bool) ([]*Route, *Error) {
+func parseRoutesFile(routesPath, joinedPath string, validate bool) ([]*Route, *Error) {
 	contentBytes, err := ioutil.ReadFile(routesPath)
 	if err != nil {
 		return nil, &Error{
@@ -166,11 +166,11 @@ func parseRoutesFile(routesPath string, validate bool) ([]*Route, *Error) {
 			Description: err.Error(),
 		}
 	}
-	return parseRoutes(routesPath, string(contentBytes), validate)
+	return parseRoutes(routesPath, joinedPath, string(contentBytes), validate)
 }
 
 // parseRoutes reads the content of a routes file into the routing table.
-func parseRoutes(routesPath, content string, validate bool) ([]*Route, *Error) {
+func parseRoutes(routesPath, joinedPath, content string, validate bool) ([]*Route, *Error) {
 	var routes []*Route
 
 	// For each line..
@@ -180,10 +180,12 @@ func parseRoutes(routesPath, content string, validate bool) ([]*Route, *Error) {
 			continue
 		}
 
+		const modulePrefix = "module:"
+
 		// Handle included routes from modules.
 		// e.g. "module:testrunner" imports all routes from that module.
-		if strings.HasPrefix(line, "module:") {
-			moduleRoutes, err := getModuleRoutes(line[len("module:"):], validate)
+		if strings.HasPrefix(line, modulePrefix) {
+			moduleRoutes, err := getModuleRoutes(line[len(modulePrefix):], joinedPath, validate)
 			if err != nil {
 				return nil, routeError(err, routesPath, content, n)
 			}
@@ -194,6 +196,25 @@ func parseRoutes(routesPath, content string, validate bool) ([]*Route, *Error) {
 		// A single route
 		method, path, action, fixedArgs, found := parseRouteLine(line)
 		if !found {
+			continue
+		}
+
+		joinChar := ""
+		if !strings.HasSuffix(joinedPath, "/") {
+			joinChar = ""
+		}
+		path = strings.Join([]string{joinedPath, path}, joinChar)
+
+		// This will import the module routes under the path described in the
+		// routes file (joinedPath param). e.g. "* /jobs/ module:jobs" -> all
+		// routes' paths will have the path /jobs/ prepended to them.
+		// See #282 for more info
+		if method == "*" && strings.HasPrefix(action, modulePrefix) {
+			moduleRoutes, err := getModuleRoutes(action[len(modulePrefix):], path, validate)
+			if err != nil {
+				return nil, routeError(err, routesPath, content, n)
+			}
+			routes = append(routes, moduleRoutes...)
 			continue
 		}
 
@@ -262,7 +283,7 @@ func routeError(err error, routesPath, content string, n int) *Error {
 
 // getModuleRoutes loads the routes file for the given module and returns the
 // list of routes.
-func getModuleRoutes(moduleName string, validate bool) ([]*Route, *Error) {
+func getModuleRoutes(moduleName, joinedPath string, validate bool) ([]*Route, *Error) {
 	// Look up the module.  It may be not found due to the common case of e.g. the
 	// testrunner module being active only in dev mode.
 	module, found := ModuleByName(moduleName)
@@ -270,7 +291,7 @@ func getModuleRoutes(moduleName string, validate bool) ([]*Route, *Error) {
 		INFO.Println("Skipping routes for inactive module", moduleName)
 		return nil, nil
 	}
-	return parseRoutesFile(path.Join(module.Path, "conf", "routes"), validate)
+	return parseRoutesFile(path.Join(module.Path, "conf", "routes"), joinedPath, validate)
 }
 
 // Groups:

--- a/router_test.go
+++ b/router_test.go
@@ -204,7 +204,7 @@ var routeMatchTestCases = map[*http.Request]*RouteMatch{
 func TestRouteMatches(t *testing.T) {
 	BasePath = "/BasePath"
 	router := NewRouter("")
-	router.Routes, _ = parseRoutes("", TEST_ROUTES, false)
+	router.Routes, _ = parseRoutes("", "", TEST_ROUTES, false)
 	router.updateTree()
 	for req, expected := range routeMatchTestCases {
 		t.Log("Routing:", req.Method, req.URL)
@@ -276,7 +276,7 @@ var reverseRoutingTestCases = map[*ReverseRouteArgs]*ActionDefinition{
 
 func TestReverseRouting(t *testing.T) {
 	router := NewRouter("")
-	router.Routes, _ = parseRoutes("", TEST_ROUTES, false)
+	router.Routes, _ = parseRoutes("", "", TEST_ROUTES, false)
 	for routeArgs, expected := range reverseRoutingTestCases {
 		actual := router.Reverse(routeArgs.action, routeArgs.args)
 		if !eq(t, "Found route", actual != nil, expected != nil) {
@@ -291,7 +291,7 @@ func TestReverseRouting(t *testing.T) {
 
 func BenchmarkRouter(b *testing.B) {
 	router := NewRouter("")
-	router.Routes, _ = parseRoutes("", TEST_ROUTES, false)
+	router.Routes, _ = parseRoutes("", "", TEST_ROUTES, false)
 	router.updateTree()
 	b.ResetTimer()
 	for i := 0; i < b.N/len(routeMatchTestCases); i++ {


### PR DESCRIPTION
Per #282, this pull request adds a `joinedPath string` parameter to the `parseRoutes`, `parseRoutesFile`, and `getModuleRoutes` methods . The reason why I chose to add the parameter instead of making modifications to the route directly at L#217 is because that would require iterating over the array of routes returned from `getModuleRoutes` and also because of the logic for creating a new Route (specifically the `TreePath` field).

Unit tests passed:

```
$ go test github.com/robfig/revel
ok      github.com/robfig/revel 0.075s
```

For an application test, clone [feature/module-url-mapping-test](https://github.com/landr0id/revel/tree/feature/module-url-mapping-test) and run the following command: `revel run github.com/robfig/revel/samples/booking`

Visit a bad path, and you should see:

```
Not Found
No matching route found

These routes have been tried, in this order :

GET       /@tests                                           TestRunner.Index
GET       /@tests.list                                      TestRunner.List
GET       /@tests/public/*filepath                          Static.ServeModule
GET       /@tests/:suite/:test                              TestRunner.Run
GET       /                                                 Application.Index
GET       /hotels                                           Hotels.Index
GET       /hotels/list                                      Hotels.List
GET       /hotels/:id                                       Hotels.Show
GET       /hotels/:id/booking                               Hotels.Book
POST      /hotels/:id/booking                               Hotels.ConfirmBooking
POST      /bookings/:id/cancel                              Hotels.CancelBooking
GET       /register                                         Application.Register
POST      /register                                         Application.SaveUser
GET       /settings                                         Hotels.Settings
POST      /settings                                         Hotels.SaveSettings
POST      /login                                            Application.Login
GET       /logout                                           Application.Logout
GET       /jobs/@jobs                                       Jobs.Status
GET       /public/*filepath                                 Static.Serve
GET       /favicon.ico                                      Static.Serve
*         /:controller/:action                              :controller.:action
```

Emphasis on `GET /jobs/@jobs Jobs.Status`.

I'll also update the routing documentation on the gh-pages branch once this is merged (assuming there are no objections to my implementation).
