### PR TITLE
Colorize take2

### DIFF
--- a/revel.go
+++ b/revel.go
@@ -1,7 +1,6 @@
 package revel
 
 import (
-    "runtime"
 	"github.com/agtorre/gocolorize"
 	"github.com/robfig/config"
 	"go/build"
@@ -11,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -20,7 +20,7 @@ const (
 
 type revelLogs struct {
 	c gocolorize.Colorize
-    w io.Writer
+	w io.Writer
 }
 
 func (r *revelLogs) Write(p []byte) (n int, err error) {
@@ -74,22 +74,20 @@ var (
 	TemplateDelims string
 
 	//Logger colors
-    colors = map[string]gocolorize.Colorize{
-        "trace": gocolorize.NewColor("magenta"),
-        "info": gocolorize.NewColor("green"),
-        "warn": gocolorize.NewColor("yellow"),
-        "error": gocolorize.NewColor("red"),
-    }
+	colors = map[string]gocolorize.Colorize{
+		"trace": gocolorize.NewColor("magenta"),
+		"info":  gocolorize.NewColor("green"),
+		"warn":  gocolorize.NewColor("yellow"),
+		"error": gocolorize.NewColor("red"),
+	}
 
-
-    error_log = revelLogs{c:colors["error"], w:os.Stderr}
+	error_log = revelLogs{c: colors["error"], w: os.Stderr}
 
 	// Loggers
 	TRACE = log.New(ioutil.Discard, "TRACE ", log.Ldate|log.Ltime|log.Lshortfile)
 	INFO  = log.New(ioutil.Discard, "INFO  ", log.Ldate|log.Ltime|log.Lshortfile)
 	WARN  = log.New(ioutil.Discard, "WARN  ", log.Ldate|log.Ltime|log.Lshortfile)
 	ERROR = log.New(&error_log, "ERROR ", log.Ldate|log.Ltime|log.Lshortfile)
-
 
 	Initialized bool
 
@@ -115,9 +113,9 @@ func Init(mode, importPath, srcPath string) {
 	SourcePath = srcPath
 	RunMode = mode
 
-    if runtime.GOOS == "windows"{
-        gocolorize.SetPlain(true)
-    }
+	if runtime.GOOS == "windows" {
+		gocolorize.SetPlain(true)
+	}
 
 	// If the SourcePath is not specified, find it using build.Import.
 	var revelSourcePath string // may be different from the app source path
@@ -206,14 +204,14 @@ func getLogger(name string) *log.Logger {
 
 	// Create a logger with the requested output. (default to stderr)
 	output := Config.StringDefault("log."+name+".output", "stderr")
-    var newlog revelLogs
+	var newlog revelLogs
 
 	switch output {
 	case "stdout":
-        newlog = revelLogs{c:colors[name], w:os.Stdout}
+		newlog = revelLogs{c: colors[name], w: os.Stdout}
 		logger = newLogger(&newlog)
 	case "stderr":
-        newlog = revelLogs{c:colors[name], w:os.Stderr}
+		newlog = revelLogs{c: colors[name], w: os.Stderr}
 		logger = newLogger(&newlog)
 	default:
 		if output == "off" {

--- a/revel/rev.go
+++ b/revel/rev.go
@@ -8,10 +8,10 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"runtime"
 	"strings"
 	"text/template"
 	"time"
-    "runtime"
 )
 
 // Cribbed from the genius organization of the "go" command.
@@ -40,7 +40,7 @@ var commands = []*Command{
 
 func main() {
 	if runtime.GOOS == "windows" {
-        gocolorize.SetPlain(true)
+		gocolorize.SetPlain(true)
 	}
 	fmt.Fprintf(os.Stdout, gocolorize.NewColor("blue").Paint(header))
 	flag.Usage = func() { usage(1) }


### PR DESCRIPTION
Update based on comments from https://github.com/robfig/revel/pull/436

The new version modifies io.Writer and colors the ENTIRE output of each logging call. Also checks if OS is Windows and if so prints plain text without ANSI codes.
