### PR TITLE
Added revel.Valid<VALIDATOR> methods for validation structs (#426)

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -14,6 +14,10 @@ type Validator interface {
 
 type Required struct{}
 
+func ValidRequired() Required {
+	return Required{}
+}
+
 func (r Required) IsSatisfied(obj interface{}) bool {
 	if obj == nil {
 		return false


### PR DESCRIPTION
These methods would remove some of the confusion when using the `revel.Validation.Check()` method from people new to the framework or validators, as shown in #423. The only struct which does not get its own method at this time is the `revel.Required` struct, mainly because of the weird name it would receive. All of the methods except for the `revel.ValidEmail()` method can be seen as alternatives to their structs. The reason why `revel.ValidEmail()` is special is because it uses the private `emailPattern`.
