### PR TITLE
Documentation additions to session, flash, field, controller, and http

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -46,6 +46,8 @@ func NewController(req *Request, resp *Response) *Controller {
 	}
 }
 
+// FlashParams serializes the contents of Controller.Params to the Flash
+// cookie.
 func (c *Controller) FlashParams() {
 	for key, vals := range c.Params.Values {
 		c.Flash.Out[key] = strings.Join(vals, ",")
@@ -143,7 +145,8 @@ func (c *Controller) RenderHtml(html string) Result {
 	return &RenderHtmlResult{html}
 }
 
-// Render a "todo" indicating that the action isn't done yet.
+// Todo returns an HTTP 501 Not Implemented "todo" indicating that the
+// action isn't done yet.
 func (c *Controller) Todo() Result {
 	c.Response.Status = http.StatusNotImplemented
 	return c.RenderError(&Error{
@@ -152,6 +155,8 @@ func (c *Controller) Todo() Result {
 	})
 }
 
+// NotFound returns an HTTP 404 Not Found response whose body is the
+// formatted string of msg and objs.
 func (c *Controller) NotFound(msg string, objs ...interface{}) Result {
 	finalText := msg
 	if len(objs) > 0 {
@@ -164,6 +169,8 @@ func (c *Controller) NotFound(msg string, objs ...interface{}) Result {
 	})
 }
 
+// Forbidden returns an HTTP 403 Forbidden response whose body is the
+// formatted string of msg and objs.
 func (c *Controller) Forbidden(msg string, objs ...interface{}) Result {
 	finalText := msg
 	if len(objs) > 0 {
@@ -176,8 +183,8 @@ func (c *Controller) Forbidden(msg string, objs ...interface{}) Result {
 	})
 }
 
-// Return a file, either displayed inline or downloaded as an attachment.
-// The name and size are taken from the file info.
+// RenderFile returns a file, either displayed inline or downloaded
+// as an attachment. The name and size are taken from the file info.
 func (c *Controller) RenderFile(file *os.File, delivery ContentDisposition) Result {
 	var (
 		modtime       = time.Now()
@@ -332,7 +339,7 @@ type MethodArg struct {
 	Type reflect.Type
 }
 
-// Searches for a given exported method (case insensitive)
+// Method searches for a given exported method (case insensitive)
 func (ct *ControllerType) Method(name string) *MethodType {
 	lowerName := strings.ToLower(name)
 	for _, method := range ct.Methods {

--- a/field.go
+++ b/field.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// Field represents a data fieid that may be collected in a web form.
+// Field represents a data field that may be collected in a web form.
 type Field struct {
 	Name       string
 	Error      *ValidationError
@@ -21,18 +21,18 @@ func NewField(name string, renderArgs map[string]interface{}) *Field {
 	}
 }
 
-// Returns an identifier suitable for use as an HTML id.
+// Id returns an identifier suitable for use as an HTML id.
 func (f *Field) Id() string {
 	return strings.Replace(f.Name, ".", "_", -1)
 }
 
-// Returned the flashed value of this field.
+// Flash returns the flashed value of this Field.
 func (f *Field) Flash() string {
 	v, _ := f.renderArgs["flash"].(map[string]string)[f.Name]
 	return v
 }
 
-// Returned the flashed value of this field as a list.
+// FlashArray returns the flashed value of this Field as a list split on comma.
 func (f *Field) FlashArray() []string {
 	v := f.Flash()
 	if v == "" {
@@ -41,7 +41,7 @@ func (f *Field) FlashArray() []string {
 	return strings.Split(v, ",")
 }
 
-// Return the current value of this field.
+// Value returns the current value of this Field.
 func (f *Field) Value() interface{} {
 	pieces := strings.Split(f.Name, ".")
 	answer, ok := f.renderArgs[pieces[0]]
@@ -63,7 +63,7 @@ func (f *Field) Value() interface{} {
 	return val.Interface()
 }
 
-// Return ERROR_CLASS if this field has a validation error, else empty string.
+// ErrorClass returns ERROR_CLASS if this field has a validation error, else empty string.
 func (f *Field) ErrorClass() string {
 	if f.Error != nil {
 		return ERROR_CLASS

--- a/flash.go
+++ b/flash.go
@@ -6,14 +6,17 @@ import (
 	"net/url"
 )
 
-// Flash represents a cookie that gets overwritten on each request.
+// Flash represents a cookie that is overwritten on each request.
 // It allows data to be stored across one page at a time.
 // This is commonly used to implement success or error messages.
-// e.g. the Post/Redirect/Get pattern: http://en.wikipedia.org/wiki/Post/Redirect/Get
+// E.g. the Post/Redirect/Get pattern:
+// http://en.wikipedia.org/wiki/Post/Redirect/Get
 type Flash struct {
 	Data, Out map[string]string
 }
 
+// Error serializes the given msg and args to an "error" key within
+// the Flash cookie.
 func (f Flash) Error(msg string, args ...interface{}) {
 	if len(args) == 0 {
 		f.Out["error"] = msg
@@ -22,6 +25,8 @@ func (f Flash) Error(msg string, args ...interface{}) {
 	}
 }
 
+// Success serializes the given msg and args to a "success" key within
+// the Flash cookie.
 func (f Flash) Success(msg string, args ...interface{}) {
 	if len(args) == 0 {
 		f.Out["success"] = msg
@@ -30,6 +35,9 @@ func (f Flash) Success(msg string, args ...interface{}) {
 	}
 }
 
+// FlashFilter is a Revel Filter that retrieves and sets the flash cookie.
+// Within Revel, it is available as a Flash attribute on Controller instances.
+// The name of the Flash cookie is set as CookiePrefix + "_FLASH".
 func FlashFilter(c *Controller, fc []Filter) {
 	c.Flash = restoreFlash(c.Request.Request)
 	c.RenderArgs["flash"] = c.Flash.Data
@@ -50,7 +58,7 @@ func FlashFilter(c *Controller, fc []Filter) {
 	})
 }
 
-// Restore flash from a request.
+// restoreFlash deserializes a Flash cookie struct from a request.
 func restoreFlash(req *http.Request) Flash {
 	flash := Flash{
 		Data: make(map[string]string),

--- a/http.go
+++ b/http.go
@@ -64,7 +64,10 @@ func ResolveContentType(req *http.Request) string {
 	return strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
 }
 
-// Resolve the accept request header.
+// ResolveFormat maps the request's Accept MIME type declaration to
+// a Request.Format attribute, specifically "html", "xml", "json", or "txt",
+// returning a default of "html" when Accept header cannot be mapped to a
+// value above.
 func ResolveFormat(req *http.Request) string {
 	accept := req.Header.Get("accept")
 
@@ -87,13 +90,13 @@ func ResolveFormat(req *http.Request) string {
 	return "html"
 }
 
-// A single language from the Accept-Language HTTP header.
+// AcceptLanguage is a single language from the Accept-Language HTTP header.
 type AcceptLanguage struct {
 	Language string
 	Quality  float32
 }
 
-// A collection of sortable AcceptLanguage instances.
+// AcceptLanguages is collection of sortable AcceptLanguage instances.
 type AcceptLanguages []AcceptLanguage
 
 func (al AcceptLanguages) Len() int           { return len(al) }
@@ -110,10 +113,12 @@ func (al AcceptLanguages) String() string {
 	return output.String()
 }
 
-// Resolve the Accept-Language header value.
+// ResolveAcceptLanguage returns a sorted list of Accept-Language
+// header values.
 //
-// The results are sorted using the quality defined in the header for each language range with the
-// most qualified language range as the first element in the slice.
+// The results are sorted using the quality defined in the header for each
+// language range with the most qualified language range as the first
+// element in the slice.
 //
 // See the HTTP header fields specification
 // (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4) for more details.


### PR DESCRIPTION
Included are documentation additions for parts of Revel I've had occasion to look into, namely session, flash, field, controller, and http. Note the one minor code cleanup in `restoreSession`, which elides a wasted `make(Session)` for the case where a cookie is present. Partial patch for #419.
