### PR TITLE
A better Slug method

### DIFF
--- a/template.go
+++ b/template.go
@@ -155,7 +155,6 @@ var (
 			return date.Format(DateTimeFormat)
 		},
 		"slug": Slug,
-		"slugify": Slugify,
 	}
 )
 


### PR DESCRIPTION
Latin-ish inputs should have very stable output. All inputs are passed through an NFKD transform, and anything still in the unicode Letter and Number categories are passed through intact. Anything in the Mark or Lm/Sk categories (modifiers) are skipped, and runs of characters from any other categories are collapsed to a single hyphen.

Taken from https://github.com/extemporalgenome/slug

Output e.g
## Original strings of input text

My daughter's dog
Šešios žąsys su šešiais žąsyčiais
Дру́жба дру́жбой, а слу́жба слу́жбой
循序渐进 [循序漸進]

---

revel slug output:
my-daughters-dog
eios-sys-su-eiais-syiais

---

new slug output:
my-daughter-s-dog
sesios-zasys-su-sesiais-zasyciais
дружба-дружбои-а-служба-службои
循序渐进-循序漸進
