### PR TITLE
Quiet a trace statement.

### DIFF
--- a/invoker.go
+++ b/invoker.go
@@ -23,7 +23,6 @@ func ActionInvoker(c *Controller, _ []Filter) {
 		if arg.Type == websocketType {
 			boundArg = reflect.ValueOf(c.Request.Websocket)
 		} else {
-			TRACE.Println("Binding:", arg.Name, "as", arg.Type)
 			boundArg = Bind(c.Params, arg.Name, arg.Type)
 		}
 		methodArgs = append(methodArgs, boundArg)


### PR DESCRIPTION
No need to see what args are bound as in the terminal all the time.
Just makes it harder to catch other messages.
