### PR TITLE
Fix key quoting in .json error templates

### DIFF
--- a/templates/errors/403.json
+++ b/templates/errors/403.json
@@ -1,4 +1,4 @@
 {
-    title: "{{js .Error.Title}}",
-    description: "{{js .Error.Description}}"
+    "title": "{{js .Error.Title}}",
+    "description": "{{js .Error.Description}}"
 }

--- a/templates/errors/404.json
+++ b/templates/errors/404.json
@@ -1,4 +1,4 @@
 {
-    title: "{{js .Error.Title}}",
-    description: "{{js .Error.Description}}"
+    "title": "{{js .Error.Title}}",
+    "description": "{{js .Error.Description}}"
 }

--- a/templates/errors/500.json
+++ b/templates/errors/500.json
@@ -1,4 +1,4 @@
 {
-	type:   "{{js .Error.Title}}",
-	message: "{{js .Error.Description}}"
+    "title": "{{js .Error.Title}}",
+    "description": "{{js .Error.Description}}"
 }


### PR DESCRIPTION
Keys need to be quoted for JSON objects to be valid. In addition, the keys in the template for 500 errors were inconsistent with the keys for the other error templates. I figured I'd change them while fixing the quoting, since the JSON being invalid means it's unlikely any project currently depends on the inconsistent keys.

edit: arg, opened this PR against the wrong branch. Will reopen in a few moments.
