### PR TITLE
Skip attribute events in watcher. Fixes issue #460

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -119,7 +119,7 @@ func (w *Watcher) Notify() *Error {
 				// Ignore changes to dotfiles.
 				if !strings.HasPrefix(path.Base(ev.Name), ".") {
 					if dl, ok := listener.(DiscerningListener); ok {
-						if !dl.WatchFile(ev.Name) {
+						if !dl.WatchFile(ev.Name) || ev.IsAttrib() {
 							continue
 						}
 					}


### PR DESCRIPTION
On filesystems with atime enabled (like OSX) an infinite loop can be
triggered. git describe --dirty which is used to set APP_VERSION
changes atime of project files and a rebuild is triggered which tries
to set the APP_VERSION. More details in the issue.
