### PR TITLE
Make files executable on `revel build`

### DIFF
--- a/revel/package_run.sh.template
+++ b/revel/package_run.sh.template
@@ -1,4 +1,3 @@
 #!/bin/sh
 SCRIPTPATH=$(cd "$(dirname "$0")"; pwd)
-chmod u+x "$SCRIPTPATH/{{.BinName}}"
 "$SCRIPTPATH/{{.BinName}}" -importPath {{.ImportPath}} -srcPath "$SCRIPTPATH/src" -runMode prod

--- a/revel/util.go
+++ b/revel/util.go
@@ -4,13 +4,14 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
-	"github.com/robfig/revel"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/robfig/revel"
 )
 
 // Use a wrapper to differentiate logged panics from unexpected ones.
@@ -53,6 +54,11 @@ func mustRenderTemplate(destPath, srcPath string, data map[string]interface{}) {
 
 	err = f.Close()
 	panicOnError(err, "Failed to close "+f.Name())
+}
+
+func mustChmod(filename string, mode os.FileMode) {
+	err := os.Chmod(filename, mode)
+	panicOnError(err, fmt.Sprintf("Failed to chmod %d %q", mode, filename))
 }
 
 // copyDir copies a directory tree over to a new directory.  Any files ending in


### PR DESCRIPTION
Fixes #467

I tried to follow this exception-like flow and wrapped `chmod` into `mustChmod`. There should be no Windows issues, as it supports `os.Chmod`.
