### PR TITLE
fix panic on certain browsers doing view source.

### DIFF
--- a/template.go
+++ b/template.go
@@ -104,7 +104,11 @@ var (
 		},
 
 		"msg": func(renderArgs map[string]interface{}, message string, args ...interface{}) template.HTML {
-			return template.HTML(Message(renderArgs[CurrentLocaleRenderArg].(string), message, args...))
+			str, ok := renderArgs[CurrentLocaleRenderArg].(string)
+			if !ok {
+				return ""
+			}
+			return template.HTML(Message(str, message, args...))
 		},
 
 		// Replaces newlines with <br>


### PR DESCRIPTION
renderArgs[CurrentLocaleRenderingArg] is not always a string, so
type check it.  On view source, renderArgs[CurrentLocaleRenderingArg]
was a nil interface{} with a msg of "404.notFound"
