### PR TITLE
Possibility targeting https for testing

### DIFF
--- a/revel/test.go
+++ b/revel/test.go
@@ -30,6 +30,11 @@ apply and may be used to determine logic in the application itself.
 
 Run mode defaults to "dev".
 
+The transport mode is used to select which http transport mode should be
+used.
+
+Transport mode defaults to "http"
+
 You can run a specific suite (and function) by specifying a third parameter.
 For example, to run all of UserTest:
 


### PR DESCRIPTION
By supplying the addition of a 3 argument `https` you can now get the tests to run over https rather than the fixed http.

Currently when you `go get` and have `http.ssl=true`, it's not possible to test via `revel test` without making manual alterations. The following change to the command allows you to supply an extra argument so you can tell it which transport mode to use `http|https`.
