### PR TITLE
type check renderArgs[CurrentLocaleRenderArg]

### DIFF
--- a/template.go
+++ b/template.go
@@ -104,7 +104,11 @@ var (
 		},
 
 		"msg": func(renderArgs map[string]interface{}, message string, args ...interface{}) template.HTML {
-			return template.HTML(Message(renderArgs[CurrentLocaleRenderArg].(string), message, args...))
+			str, ok := renderArgs[CurrentLocaleRenderArg].(string)
+			if !ok {
+				return ""
+			}
+			return template.HTML(Message(str, message, args...))
 		},
 
 		// Replaces newlines with <br>


### PR DESCRIPTION
renderArgs[CurrentLocaleRenderArg] is not always a string, as seen when some browers "view source".  Add a type check here which stops revel from panicking.
