### PR TITLE
Print a more useful representation of the address when listening

### DIFF
--- a/server.go
+++ b/server.go
@@ -94,7 +94,7 @@ func Run(port int) {
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		fmt.Printf("Listening on %s...\n", address)
+		fmt.Printf("Listening on %s...\n", localAddress)
 	}()
 
 	if HttpSsl {


### PR DESCRIPTION
The port doesn't get included if just `address` is printed.
