### PR TITLE
Add Date and Message-Id mail headers

### DIFF
--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -94,6 +94,7 @@ From: foo@bar.com
 To: bar@foo.com 
 Cc: cc1@test.com, cc2@test.com 
 Subject: from message1, single connection 
+Message-Id: <message-id1@bar.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
 Content-Type: text/plain; charset="UTF-8";
@@ -111,6 +112,7 @@ DATA
 From: abc@test.com 
 To: def@test.com, nonoo@test.com 
 Subject: =?UTF-8?B?6L+Z5Liq5piv56ysMuWwgWZyb20gbWVzc2FnZTIsIHNpbmdsZSBjb25uZWN0aW9u?= 
+Message-Id: <message-id2@test.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
 Content-Type: text/html; charset="UTF-8";
@@ -124,10 +126,12 @@ QUIT
 	mailer := &Mailer{Server: "smtp.gmail.com", Port: 587, UserName: "foo@bar.com", Password: "xxx"}
 
 	message1 := &Message{From: "foo@bar.com", To: []string{"bar@foo.com"}, Cc: []string{"cc1@test.com", "cc2@test.com"},
-		Subject: "from message1, single connection", PlainBody: bytes.NewBufferString("<h2>你好 from message1, should show in plain text</h2>"), Date: testDate}
+		Subject: "from message1, single connection", PlainBody: bytes.NewBufferString("<h2>你好 from message1, should show in plain text</h2>"),
+		Date: testDate, MessageId: "message-id1@bar.com"}
 
 	message2 := &Message{From: "abc@test.com", To: []string{"def@test.com", "nonoo@test.com"}, Bcc: []string{"bcc1@test.com", "bcc2@test.com"},
-		Subject: "这个是第2封from message2, single connection", HtmlBody: bytes.NewBufferString("<h2>您好 from message2</h2>"), Date: testDate}
+		Subject: "这个是第2封from message2, single connection", HtmlBody: bytes.NewBufferString("<h2>您好 from message2</h2>"),
+		Date: testDate, MessageId: "message-id2@test.com"}
 
 	actualcmds, err := mailer.SendTestMessage(server, message1, message2)
 	if err != nil {
@@ -172,6 +176,7 @@ From: sender@test.com
 Reply-To: reply@test.com 
 To: to1@test.com 
 Subject: =?UTF-8?B?5oiR55qE56ysM+S4qg==?= 
+Message-Id: <message-id1@test.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
 Content-Type: text/plain; charset="UTF-8";
@@ -187,6 +192,7 @@ From: sender@test.com
 Reply-To: reply@test.com 
 To: to2@test.com 
 Subject: =?UTF-8?B?5oiR55qE56ysNOS4qg==?= 
+Message-Id: <message-id2@test.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
 Content-Type: text/html; charset="UTF-8";
@@ -202,6 +208,7 @@ From: sender@test.com
 Reply-To: reply@test.com 
 To: to3@test.com 
 Subject: =?UTF-8?B?5oiR55qE56ysNeS4qg==?= 
+Message-Id: <message-id3@test.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
 `
@@ -212,10 +219,16 @@ MIME-Version: 1.0
 
 	message1 := NewTextMessage([]string{"to1@test.com"}, "我的第3个", "这个不是html的")
 	message1.Date = testDate
+	message1.MessageId = "message-id1@test.com"
+
 	message2 := NewHtmlMessage([]string{"to2@test.com"}, "我的第4个", "<h1>这个是html的</h1>")
 	message2.Date = testDate
+	message2.MessageId = "message-id2@test.com"
+
 	message3 := NewTextAndHtmlMessage([]string{"to3@test.com"}, "我的第5个", "这个不是html的", "<h1>这个是html的, 同时也有plain text 版本</h1>")
 	message3.Date = testDate
+	message3.MessageId = "message-id3@test.com"
+
 	actualcmds, err := mailer.SendTestMessage(server, []*Message{message1, message2, message3}...)
 	if err != nil {
 		fmt.Println(err)

--- a/mail/message.go
+++ b/mail/message.go
@@ -24,7 +24,9 @@ type Message struct {
 	Subject   string
 	PlainBody *bytes.Buffer
 	HtmlBody  *bytes.Buffer
+
 	Date      time.Time
+	MessageId string
 }
 
 // NewTextMessage create a plain text message
@@ -93,6 +95,10 @@ func (m *Message) renderSingleContentType(contentType string, bodyText *bytes.Bu
 	var b bytes.Buffer
 	m.writeRecipient(&b)
 
+	if err := m.writeMessageId(&b); err != nil {
+		return nil, err
+	}
+
 	if err := m.writeDate(&b); err != nil {
 		return nil, err
 	}
@@ -116,6 +122,10 @@ func (m *Message) renderPlainAndHtmlText() ([]byte, error) {
 	writer := multipart.NewWriter(bytes.NewBufferString(""))
 	var b bytes.Buffer
 	m.writeRecipient(&b)
+
+	if err := m.writeMessageId(&b); err != nil {
+		return nil, err
+	}
 
 	if err := m.writeDate(&b); err != nil {
 		return nil, err
@@ -185,6 +195,15 @@ func (m *Message) writeDate(b *bytes.Buffer) error {
 	}
 
 	_, err := b.WriteString("Date: " + m.Date.UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT") + "\n")
+	return err
+}
+
+func (m *Message) writeMessageId(b *bytes.Buffer) error {
+	if m.MessageId == "" {
+		return nil
+	}
+
+	_, err := b.WriteString("Message-Id: <" + m.MessageId + ">\n")
 	return err
 }
 

--- a/mail/message_test.go
+++ b/mail/message_test.go
@@ -60,6 +60,7 @@ func TestRenderPlainAndHtmlText(t *testing.T) {
 		PlainBody: bytes.NewBufferString(plainBody),
 		HtmlBody:  bytes.NewBufferString(htmlBody),
 		Date:      testDate,
+		MessageId: "message-id@bar.com",
 	}
 
 	b, _ := message.RenderData()
@@ -75,5 +76,9 @@ func TestRenderPlainAndHtmlText(t *testing.T) {
 
 	if !strings.Contains(recipient, "Date: Sun, 23 Feb 2014 00:00:00 GMT") {
 		t.Error("Message should have the Date header set")
+	}
+
+	if !strings.Contains(recipient, "Message-Id: <message-id@bar.com>") {
+		t.Error("Message should have the Message-Id header set")
 	}
 }


### PR DESCRIPTION
These headers are important for passing certain spam filters.

This implementation automatically fills in the date if not specified, since you pretty much always want it set. However, it does not attempt to automatically generate a `Message-Id` and leaves it up to the caller to determine a unique id for the message.

Here's an example SpamAssassin report for an email missing the `Date` and `Message-Id` headers (note, higher numbers means more spammy):

```
* 0.0 SPF_PASS SPF: sender matches SPF record
* 0.1 HTML_MESSAGE BODY: HTML included in message
* 3.0 BAYES_95 BODY: Bayes spam probability is 95 to 99%
* [score: 0.9680]
* 0.5 MISSING_MID Missing Message-Id: header
* 1.4 MISSING_DATE Missing Date: header
* 0.0 T_REMOTE_IMAGE Message contains an external image
```

Notice how `MISSING_DATE` adds an additional half of the score increase that a 97% spammy body adds.

cc @xthexder
