### PR TITLE
fixes path bug. appPath -> importPath on line 131. removed a println

### DIFF
--- a/revel/new.go
+++ b/revel/new.go
@@ -126,9 +126,11 @@ func setApplicationPath(args []string) {
 		errorf("Abort: Could not find Revel source code: %s\n", err)
 	}
 
+	// appPath is an absolute directory for copying files
 	appPath = filepath.Join(srcRoot, filepath.FromSlash(importPath))
-	appName = filepath.Base(appPath)
+	// basePath is a relative directory for use in skeleton templates
 	basePath = filepath.ToSlash(filepath.Dir(importPath))
+	appName = filepath.Base(appPath)
 
 	if basePath == "." {
 		// we need to remove the a single '.' when


### PR DESCRIPTION
This was causing the templated include paths to be absolute

resulted from the initGoPaths() being called and not updating line 131
