### PR TITLE
Surround attachment filename in quotes

### DIFF
--- a/results.go
+++ b/results.go
@@ -269,7 +269,7 @@ type BinaryResult struct {
 func (r *BinaryResult) Apply(req *Request, resp *Response) {
 	disposition := string(r.Delivery)
 	if r.Name != "" {
-		disposition += fmt.Sprintf("; filename=%s", r.Name)
+		disposition += fmt.Sprintf(`; filename="%s"`, r.Name)
 	}
 	resp.Out.Header().Set("Content-Disposition", disposition)
 


### PR DESCRIPTION
Certain browsers (Firefox) will truncate the filename if there's a space. Ideally we should do a bunch of fancy unicode handling (check out the headers sent by Gmail for a filename with utf-8 in it...) but this is a good solution for the short term.

There are no tests for this; there should probably be tests for this. I need to use this patch ASAP though, and don't have time to write a test suite for `BinaryResult` at the moment.

cc @xthexder
