### PR TITLE
Use Revel's loggers in more cases

### DIFF
--- a/modules/jobs/app/jobs/plugin.go
+++ b/modules/jobs/app/jobs/plugin.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"fmt"
 	"github.com/revel/revel"
 	"github.com/robfig/cron"
 )
@@ -27,6 +26,6 @@ func init() {
 		}
 		selfConcurrent = revel.Config.BoolDefault("jobs.selfconcurrent", false)
 		MainCron.Start()
-		fmt.Println("Go to /@jobs to see job status.")
+		revel.INFO.Print("Go to /@jobs to see job status.")
 	})
 }

--- a/modules/testrunner/app/plugin.go
+++ b/modules/testrunner/app/plugin.go
@@ -1,12 +1,11 @@
 package app
 
 import (
-	"fmt"
 	"github.com/revel/revel"
 )
 
 func init() {
 	revel.OnAppStart(func() {
-		fmt.Println("Go to /@tests to run the tests.")
+		revel.INFO.Print("Go to /@tests to run the tests.")
 	})
 }

--- a/server.go
+++ b/server.go
@@ -2,7 +2,6 @@ package revel
 
 import (
 	"code.google.com/p/go.net/websocket"
-	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -96,7 +95,7 @@ func Run(port int) {
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		fmt.Printf("Listening on %s...\n", localAddress)
+		INFO.Printf("Listening on %s...\n", localAddress)
 	}()
 
 	if HttpSsl {


### PR DESCRIPTION
There were a few places in the core framework that were still using `fmt.Print*`, which means that those logs couldn't be captured by overwriting the loggers.
