### PR TITLE
enhancement / templateFunc `firstof`

### DIFF
--- a/template.go
+++ b/template.go
@@ -59,7 +59,7 @@ var (
 		},
 		"field": NewField,
 		"firstof": func(args ...interface{}) interface{} {
-			for i, val := range args {
+			for _, val := range args {
 				switch val.(type) {
 				case nil:
 					continue


### PR DESCRIPTION
added template function `firstof` to return the first non-'null' argument
per the `coalesce` in https://github.com/Jetvp/revel/commit/b67c19c0aaebfbd818e6ffc0a597ac48bcc30397

this should help deal with issues: #221 #451

example:

`{{firstof $field.Flash $field.Value}}`
`{{first of .User .Guest}}`

Not the params thing though
