### PR TITLE
Fix #563 -- Some custom template funcs cannot be used in JavaScript cont...

### DIFF
--- a/template.go
+++ b/template.go
@@ -45,17 +45,17 @@ var (
 	TemplateFuncs = map[string]interface{}{
 		"url": ReverseUrl,
 		"eq":  Equal,
-		"set": func(renderArgs map[string]interface{}, key string, value interface{}) template.HTML {
+		"set": func(renderArgs map[string]interface{}, key string, value interface{}) template.JS {
 			renderArgs[key] = value
-			return template.HTML("")
+			return template.JS("")
 		},
-		"append": func(renderArgs map[string]interface{}, key string, value interface{}) template.HTML {
+		"append": func(renderArgs map[string]interface{}, key string, value interface{}) template.JS {
 			if renderArgs[key] == nil {
 				renderArgs[key] = []interface{}{value}
 			} else {
 				renderArgs[key] = append(renderArgs[key].([]interface{}), value)
 			}
-			return template.HTML("")
+			return template.JS("")
 		},
 		"field": NewField,
 		"option": func(f *Field, val, label string) template.HTML {


### PR DESCRIPTION
This fix essentially allows the functions which _always_ return nothing (i.e. `set` and `append`) to be used within the context of JavaScript.

I explain in #563 but basically by returning `template.HTML`, the template engine will insert quotes if these methods are used within a `<script>` element or a `.js` file (not sure about that one, but I read a SO question where someone was encountering that).
