### PR TITLE
Fixed regex pattern to properly require message files to have a dot in filename

### DIFF
--- a/i18n.go
+++ b/i18n.go
@@ -13,7 +13,7 @@ const (
 	CurrentLocaleRenderArg = "currentLocale" // The key for the current locale render arg value
 
 	messageFilesDirectory = "messages"
-	messageFilePattern    = `^\w+.[a-zA-Z]{2}$`
+	messageFilePattern    = `^\w+\.[a-zA-Z]{2}$`
 	unknownValueFormat    = "??? %s ???"
 	defaultLanguageOption = "i18n.default_language"
 	localeCookieConfigKey = "i18n.cookie"


### PR DESCRIPTION
Fix the matching of messages files.

This may be related to https://github.com/revel/revel/pull/561
