### PR TITLE
Log errors that occur when rendering an email template

### DIFF
--- a/mail/message.go
+++ b/mail/message.go
@@ -78,6 +78,7 @@ func (m *Message) renderViewTemplate(templateFilePath string, args map[string]in
 	// Get the Template.
 	template, err := revel.MainTemplateLoader.Template(templateFilePath)
 	if err != nil {
+		revel.ERROR.Print(err)
 		return nil
 	}
 
@@ -85,6 +86,7 @@ func (m *Message) renderViewTemplate(templateFilePath string, args map[string]in
 
 	err = template.Render(&b, args)
 	if err != nil {
+		revel.ERROR.Print(err)
 		return nil
 	}
 


### PR DESCRIPTION
Presently, any typos or other errors in email templates are ignored. If you have errors in both formats, you end up with a cryptic "Both HTML body and Plain body are blank" message. This at least lets the developer know what the heck they did wrong.
