### PR TITLE
Make the option template tag type agnostic.

### DIFF
--- a/template.go
+++ b/template.go
@@ -58,13 +58,16 @@ var (
 			return template.HTML("")
 		},
 		"field": NewField,
-		"option": func(f *Field, val, label string) template.HTML {
+		"option": func(f *revel.Field, val interface{}, label string) template.HTML {
 			selected := ""
 			if f.Flash() == val {
 				selected = " selected"
+			} else if f.Flash() == "" && f.Value() == val {
+				selected = " selected"
 			}
+
 			return template.HTML(fmt.Sprintf(`<option value="%s"%s>%s</option>`,
-				html.EscapeString(val), selected, html.EscapeString(label)))
+				html.EscapeString(fmt.Sprintf("%v", val)), selected, html.EscapeString(label)))
 		},
 		"radio": func(f *Field, val string) template.HTML {
 			checked := ""


### PR DESCRIPTION
This commit contains two enhancements.
First: Set the element to selected if the flash is empty, and the current field value equals the value passed in.

Second: The type of the val passed in is now a generic interface{} so that integar values passed in match the value of the field.
Without this change, integer fields passed into val are turned into strings, and will not match the integer value reported by f.Value()
