### PR TITLE
Add 'even' template tag to assist row coloring.

### DIFF
--- a/template.go
+++ b/template.go
@@ -157,6 +157,7 @@ var (
 			return date.Format(DateTimeFormat)
 		},
 		"slug": Slug,
+		"even": func(a int) bool { return (a % 2) == 0 },
 	}
 )
 


### PR DESCRIPTION
Even though this feature is possible to implement at another layer (notably css nth child), some times you just can not avoid doing this work server side. This tag is simple and useful enough to merit inclusion in the main distribution.
