### PR TITLE
Realtime rebuild

### DIFF
--- a/skeleton/conf/app.conf.template
+++ b/skeleton/conf/app.conf.template
@@ -114,8 +114,9 @@ results.pretty = true
 watch = true
 
 
-# Start to recompile every time your application file changes.
-rebuild.eager = false
+# If you set watcher.mode = "eager", the server starts to recompile
+# your application every time your application's files change.
+watcher.mode = "normal"
 
 
 # Module to run code tests in the browser

--- a/watcher.go
+++ b/watcher.go
@@ -206,7 +206,7 @@ func (w *Watcher) Notify() *Error {
 func (w *Watcher) eagerRebuildEnabled() bool {
 	return Config.BoolDefault("mode.dev", true) &&
 		Config.BoolDefault("watch", true) &&
-		Config.BoolDefault("rebuild.eager", false)
+		Config.StringDefault("watcher.mode", "normal") == "eager"
 }
 
 func (w *Watcher) rebuildRequired(ev fsnotify.Event, listener Listener) bool {


### PR DESCRIPTION
## Problem

Because Revel receives file change events when receiving HTTP requests, 
Revel does not rebuild an application until a browser reload or something.
## Solution

But you can start to rebuild the application when the file is changed if you watch file change events in real time.
So I created goroutine to receive them.

Because a select statement without default case waits until receiving events, its performance didn't become worse.
