### PR TITLE
Expose redis cache options to config.

### DIFF
--- a/cache/redis.go
+++ b/cache/redis.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"github.com/garyburd/redigo/redis"
+	"github.com/revel/revel"
 	"time"
 )
 
@@ -14,11 +15,12 @@ type RedisCache struct {
 // until redigo supports sharding/clustering, only one host will be in hostList
 func NewRedisCache(host string, password string, defaultExpiration time.Duration) RedisCache {
 	var pool = &redis.Pool{
-		MaxIdle:     5,
-		IdleTimeout: 240 * time.Second,
+		MaxIdle:     revel.Config.IntDefault("cache.redis.maxidle", 5),
+		MaxActive:   revel.Config.IntDefault("cache.redis.maxactive", 0),
+		IdleTimeout: time.Duration(revel.Config.IntDefault("cache.redis.idletimeout", 240)) * time.Second,
 		Dial: func() (redis.Conn, error) {
-			// the redis protocol should probably be made sett-able
-			c, err := redis.Dial("tcp", host)
+			protocol := revel.Config.StringDefault("cache.redis.protocol", "tcp")
+			c, err := redis.Dial(protocol, host)
 			if err != nil {
 				return nil, err
 			}

--- a/cache/redis_test.go
+++ b/cache/redis_test.go
@@ -4,12 +4,21 @@ import (
 	"net"
 	"testing"
 	"time"
+	"github.com/revel/revel"
 )
 
 // These tests require redis server running on localhost:6379 (the default)
 const redisTestServer = "localhost:6379"
+const testConfigPath string = "testdata"
+const testConfigName string = "test_app.conf"
 
 var newRedisCache = func(t *testing.T, defaultExpiration time.Duration) Cache {
+	revel.ConfPaths = append(revel.ConfPaths, testConfigPath)
+	var err error
+	revel.Config, err = revel.LoadConfig(testConfigName)
+	if err != nil {
+		t.Fatalf("couldn't load config %s/%s : %s", revel.ConfPaths, testConfigName, err.Error())
+	}
 	c, err := net.Dial("tcp", redisTestServer)
 	if err == nil {
 		c.Write([]byte("flush_all\r\n"))

--- a/cache/testdata/test_app.conf
+++ b/cache/testdata/test_app.conf
@@ -1,0 +1,33 @@
+app.name={{ .AppName }}
+app.secret={{ .Secret }}
+http.addr=
+http.port=9000
+cookie.prefix=REVEL
+
+i18n.default_language=en
+i18n.cookie=APP_LANG
+
+[dev]
+results.pretty=true
+results.staging=true
+watch=true
+
+module.testrunner = github.com/revel/revel/modules/testrunner
+module.static=github.com/revel/revel/modules/static
+
+log.trace.output = off
+log.info.output  = stderr
+log.warn.output  = stderr
+log.error.output = stderr
+
+[prod]
+results.pretty=false
+results.staging=false
+watch=false
+
+module.testrunner =
+
+log.trace.output = off
+log.info.output  = off
+log.warn.output  = %(app.name)s.log
+log.error.output = %(app.name)s.log


### PR DESCRIPTION
This patch adds "cache.redis.maxidle", "cache.redis.maxactive", "cache.redis.protocol" as config keys. Default values are the previous defaults (5, 0, "tcp").

(Now targeting development branch)
