### PR TITLE
Support template engine

### DIFF
--- a/fakeapp_test.go
+++ b/fakeapp_test.go
@@ -73,7 +73,7 @@ func startFakeBookingApp() {
 	routesFile, _ := ioutil.ReadFile(filepath.Join(BasePath, "conf", "routes"))
 	MainRouter.Routes, _ = parseRoutes("", "", string(routesFile), false)
 	MainRouter.updateTree()
-	MainTemplateLoader = NewTemplateLoader([]string{ViewsPath, path.Join(RevelPath, "templates")})
+	MainTemplateLoader = NewTemplateLoader("default", []string{ViewsPath, path.Join(RevelPath, "templates")})
 	MainTemplateLoader.Refresh()
 
 	RegisterController((*Hotels)(nil),

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -81,8 +81,7 @@ func (hp *Harness) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func NewHarness() *Harness {
 	// Get a template loader to render errors.
 	// Prefer the app's views/errors directory, and fall back to the stock error pages.
-	revel.MainTemplateLoader = revel.NewTemplateLoader(
-		[]string{path.Join(revel.RevelPath, "templates")})
+	revel.MainTemplateLoader = revel.NewTemplateLoader("default", []string{path.Join(revel.RevelPath, "templates")})
 	revel.MainTemplateLoader.Refresh()
 
 	addr := revel.HttpAddr

--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -90,10 +90,10 @@ RCPT TO:<bar@foo.com>
 RCPT TO:<cc1@test.com>
 RCPT TO:<cc2@test.com>
 DATA
-From: foo@bar.com 
-To: bar@foo.com 
-Cc: cc1@test.com, cc2@test.com 
-Subject: from message1, single connection 
+From: foo@bar.com
+To: bar@foo.com
+Cc: cc1@test.com, cc2@test.com
+Subject: from message1, single connection
 Message-Id: <message-id1@bar.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
@@ -109,9 +109,9 @@ RCPT TO:<nonoo@test.com>
 RCPT TO:<bcc1@test.com>
 RCPT TO:<bcc2@test.com>
 DATA
-From: abc@test.com 
-To: def@test.com, nonoo@test.com 
-Subject: =?UTF-8?B?6L+Z5Liq5piv56ysMuWwgWZyb20gbWVzc2FnZTIsIHNpbmdsZSBjb25uZWN0aW9u?= 
+From: abc@test.com
+To: def@test.com, nonoo@test.com
+Subject: =?UTF-8?B?6L+Z5Liq5piv56ysMuWwgWZyb20gbWVzc2FnZTIsIHNpbmdsZSBjb25uZWN0aW9u?=
 Message-Id: <message-id2@test.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
@@ -172,10 +172,10 @@ RSET
 MAIL FROM:<sender@test.com>
 RCPT TO:<to1@test.com>
 DATA
-From: sender@test.com 
-Reply-To: reply@test.com 
-To: to1@test.com 
-Subject: =?UTF-8?B?5oiR55qE56ysM+S4qg==?= 
+From: sender@test.com
+Reply-To: reply@test.com
+To: to1@test.com
+Subject: =?UTF-8?B?5oiR55qE56ysM+S4qg==?=
 Message-Id: <message-id1@test.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
@@ -188,10 +188,10 @@ RSET
 MAIL FROM:<sender@test.com>
 RCPT TO:<to2@test.com>
 DATA
-From: sender@test.com 
-Reply-To: reply@test.com 
-To: to2@test.com 
-Subject: =?UTF-8?B?5oiR55qE56ysNOS4qg==?= 
+From: sender@test.com
+Reply-To: reply@test.com
+To: to2@test.com
+Subject: =?UTF-8?B?5oiR55qE56ysNOS4qg==?=
 Message-Id: <message-id2@test.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
@@ -204,10 +204,10 @@ RSET
 MAIL FROM:<sender@test.com>
 RCPT TO:<to3@test.com>
 DATA
-From: sender@test.com 
-Reply-To: reply@test.com 
-To: to3@test.com 
-Subject: =?UTF-8?B?5oiR55qE56ysNeS4qg==?= 
+From: sender@test.com
+Reply-To: reply@test.com
+To: to3@test.com
+Subject: =?UTF-8?B?5oiR55qE56ysNeS4qg==?=
 Message-Id: <message-id3@test.com>
 Date: Sun, 23 Feb 2014 00:00:00 GMT
 MIME-Version: 1.0
@@ -269,7 +269,7 @@ http://www.arkxu.com
 
 	// reset the revel template loader for testing purpose
 	viewPath, _ := os.Getwd()
-	revel.MainTemplateLoader = revel.NewTemplateLoader([]string{viewPath})
+	revel.MainTemplateLoader = revel.NewTemplateLoader("default", []string{viewPath})
 	revel.MainTemplateLoader.Refresh()
 
 	// arguments used for template rendering

--- a/server.go
+++ b/server.go
@@ -70,7 +70,7 @@ func Run(port int) {
 		localAddress = address + ":" + strconv.Itoa(port)
 	}
 
-	MainTemplateLoader = NewTemplateLoader(TemplatePaths)
+	MainTemplateLoader = NewTemplateLoader("default", TemplatePaths)
 
 	// The "watch" config variable can turn on and off all watching.
 	// (As a convenient way to control it all together.)

--- a/server.go
+++ b/server.go
@@ -70,7 +70,7 @@ func Run(port int) {
 		localAddress = address + ":" + strconv.Itoa(port)
 	}
 
-	MainTemplateLoader = NewTemplateLoader("default", TemplatePaths)
+	MainTemplateLoader = NewTemplateLoader(Config.StringDefault("template.engine", "default"), TemplatePaths)
 
 	// The "watch" config variable can turn on and off all watching.
 	// (As a convenient way to control it all together.)

--- a/server.go
+++ b/server.go
@@ -71,6 +71,7 @@ func Run(port int) {
 	}
 
 	MainTemplateLoader = NewTemplateLoader(Config.StringDefault("template.engine", "default"), TemplatePaths)
+	MainTemplateLoader.SetConfig(Config)
 
 	// The "watch" config variable can turn on and off all watching.
 	// (As a convenient way to control it all together.)

--- a/template.go
+++ b/template.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/robfig/config"
 )
 
 func init() {
@@ -197,7 +199,8 @@ var (
 
 type TemplateEnginer interface {
 	Parse(s string) (*template.Template, error)
-	SetHelpers(funcs template.FuncMap)
+	SetOptions(options *config.Config)
+	SetHelpers(helpers template.FuncMap)
 	WatchDir(dir os.FileInfo) bool
 	WatchFile(file string) bool
 }
@@ -462,6 +465,7 @@ func (gotmpl GoTemplate) Content() []string {
 //////////////////////
 type GoTemplateEngine struct {
 	driver  *template.Template
+	options *config.Config
 	helpers template.FuncMap
 	counter uint32
 }
@@ -478,6 +482,10 @@ func (engine *GoTemplateEngine) Parse(s string) (*template.Template, error) {
 	engine.counter += 1
 
 	return engine.driver.New(fmt.Sprintf("[#%d] GO TEMPLATE ENGINE", engine.counter)).Parse(s)
+}
+
+func (engine *GoTemplateEngine) SetOptions(options *config.Config) {
+	engine.options = options
 }
 
 func (engine *GoTemplateEngine) SetHelpers(helpers template.FuncMap) {

--- a/template.go
+++ b/template.go
@@ -287,6 +287,7 @@ func (loader *TemplateLoader) Refresh() *Error {
 	TRACE.Printf("Refreshing templates from %s", loader.paths)
 
 	loader.engineError = nil
+  loader.templateSet = template.New("").Funcs(TemplateHelpers)
 	loader.templatePaths = map[string]string{}
 
 	// Walk through the template loader's paths and build up a template set.

--- a/template.go
+++ b/template.go
@@ -6,7 +6,6 @@ import (
 	"html/template"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -16,36 +15,43 @@ import (
 	"time"
 )
 
-var ERROR_CLASS = "hasError"
-
-// This object handles loading and parsing of templates.
-// Everything below the application's views directory is treated as a template.
-type TemplateLoader struct {
-	// This is the set of all templates under views
-	templateSet *template.Template
-	// If an error was encountered parsing the templates, it is stored here.
-	compileError *Error
-	// Paths to search for templates, in priority order.
-	paths []string
-	// Map from template name to the path from whence it was loaded.
-	templatePaths map[string]string
-}
-
-type Template interface {
-	Name() string
-	Content() []string
-	Render(wr io.Writer, arg interface{}) error
-}
-
-var invalidSlugPattern = regexp.MustCompile(`[^a-z0-9 _-]`)
-var whiteSpacePattern = regexp.MustCompile(`\s+`)
-
 var (
-	// The functions available for use in the templates.
-	TemplateFuncs = map[string]interface{}{
-		"url": ReverseUrl,
-		"eq":  Equal,
-		"set": func(renderArgs map[string]interface{}, key string, value interface{}) template.JS {
+	ERROR_CLASS = "hasError"
+
+	invalidSlugPattern = regexp.MustCompile(`[^a-z0-9 _-]`)
+	whiteSpacePattern  = regexp.MustCompile(`\s+`)
+
+	// The default functions available for use in the templates.
+	TemplateFuncs = template.FuncMap{
+		// Return a url capable of invoking a given controller method:
+		// "Application.ShowApp 123" => "/app/123"
+		"url": func(args ...interface{}) (string, error) {
+			if len(args) == 0 {
+				return "", fmt.Errorf("no arguments provided to reverse route")
+			}
+
+			action := args[0].(string)
+			actionSplit := strings.Split(action, ".")
+			if len(actionSplit) != 2 {
+				return "", fmt.Errorf("reversing '%s', expected 'Controller.Action'", action)
+			}
+
+			// Look up the types.
+			var c Controller
+			if err := c.SetAction(actionSplit[0], actionSplit[1]); err != nil {
+				return "", fmt.Errorf("reversing %s: %s", action, err)
+			}
+
+			// Unbind the arguments.
+			argsByName := make(map[string]string)
+			for i, argValue := range args[1:] {
+				Unbind(argsByName, c.MethodType.Args[i].Name, argValue)
+			}
+
+			return MainRouter.Reverse(args[0].(string), argsByName).Url, nil
+		},
+		"eq": Equal,
+		"set": func(renderArgs map[string]interface{}, key string, value interface{}) template.HTML {
 			renderArgs[key] = value
 			return template.JS("")
 		},
@@ -173,51 +179,92 @@ var (
 		"datetime": func(date time.Time) string {
 			return date.Format(DateTimeFormat)
 		},
-		"slug": Slug,
 		"even": func(a int) bool { return (a % 2) == 0 },
+		"slug": func(text string) string {
+			separator := "-"
+			text = strings.ToLower(text)
+			text = invalidSlugPattern.ReplaceAllString(text, "")
+			text = whiteSpacePattern.ReplaceAllString(text, separator)
+			text = strings.Trim(text, separator)
+			return text
+		},
 	}
 )
 
-func NewTemplateLoader(paths []string) *TemplateLoader {
-	loader := &TemplateLoader{
-		templateSet: template.New("").Funcs(TemplateFuncs),
-		paths:       paths,
-	}
-	return loader
+type TemplateEnginer interface {
+	Parse(s string) (*template.Template, error)
+	SetHelpers(funcs template.FuncMap)
+	WatchDir(dir os.FileInfo) bool
+	WatchFile(file string) bool
 }
 
-// This scans the views directory and parses all templates as Go Templates.
+type Template interface {
+	Name() string
+	Content() []string
+	Render(wr io.Writer, arg interface{}) error
+}
+
+// This object handles loading and parsing of templates.
+// Everything below the application's views directory is treated as a template.
+type TemplateLoader struct {
+	// template parse engine
+	engine TemplateEnginer
+
+	// If any error was encountered parsing the templates, it is stored here.
+	engineError *Error
+
+	// Paths to search for templates, in priority order.
+	paths []string
+
+	// This is the set of all templates under views
+	templateSet *template.Template
+	// Map from template name to the path from whence it was loaded.
+	templatePaths map[string]string
+}
+
+func NewTemplateLoader(paths []string) *TemplateLoader {
+	enginer := NewGoTemplateEngine()
+	enginer.SetHelpers(TemplateFuncs)
+
+	return &TemplateLoader{
+		engine:      enginer,
+		paths:       paths,
+		templateSet: template.New("").Funcs(TemplateFuncs),
+	}
+}
+
+// This scans the views directory and parses all templates using engine as Go Templates.
 // If a template fails to parse, the error is set on the loader.
 // (It's awkward to refresh a single Go Template)
 func (loader *TemplateLoader) Refresh() *Error {
 	TRACE.Printf("Refreshing templates from %s", loader.paths)
 
-	loader.compileError = nil
+	loader.engineError = nil
 	loader.templatePaths = map[string]string{}
 
-	// Set the template delimiters for the project if present, then split into left
-	// and right delimiters around a space character
-	var splitDelims []string
-	if TemplateDelims != "" {
-		splitDelims = strings.Split(TemplateDelims, " ")
-		if len(splitDelims) != 2 {
-			log.Fatalln("app.conf: Incorrect format for template.delimiters")
-		}
-	}
+	// // Set the template delimiters for the project if present, then split into left
+	// // and right delimiters around a space character
+	// var splitDelims []string
+	// if TemplateDelims != "" {
+	// 	splitDelims = strings.Split(TemplateDelims, " ")
+	// 	if len(splitDelims) != 2 {
+	// 		log.Fatalln("app.conf: Incorrect format for template.delimiters")
+	// 	}
+	// }
 
 	// Walk through the template loader's paths and build up a template set.
 	for _, basePath := range loader.paths {
 		// Walk only returns an error if the template loader is completely unusable
 		// (namely, if one of the TemplateFuncs does not have an acceptable signature).
-		funcErr := filepath.Walk(basePath, func(path string, info os.FileInfo, err error) error {
+		walkErr := filepath.Walk(basePath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				ERROR.Println("error walking templates:", err)
+				ERROR.Println("[filepath.Walk] ", path, " : ", err)
 				return nil
 			}
 
 			// Walk into watchable directories
 			if info.IsDir() {
-				if !loader.WatchDir(info) {
+				if !loader.engine.WatchDir(info) {
 					return filepath.SkipDir
 				}
 
@@ -225,11 +272,11 @@ func (loader *TemplateLoader) Refresh() *Error {
 			}
 
 			// Only add watchable
-			if !loader.WatchFile(info.Name()) {
+			if !loader.engine.WatchFile(info.Name()) {
 				return nil
 			}
 
-			var fileStr string
+			var templateString string
 
 			// addTemplate allows the same template to be added multiple
 			// times with different template names.
@@ -246,60 +293,57 @@ func (loader *TemplateLoader) Refresh() *Error {
 				loader.templatePaths[name] = path
 
 				// Load the file if we haven't already
-				if fileStr == "" {
+				if templateString == "" {
 					fileBytes, err := ioutil.ReadFile(path)
 					if err != nil {
-						ERROR.Println("Failed reading file:", path)
+						ERROR.Println("[ioutil.ReadFile] ", path, " : ", err.Error())
 						return nil
 					}
 
-					fileStr = string(fileBytes)
+					templateString = string(fileBytes)
 				}
 
-				// Create the template set.  This panics if any of the funcs do not
-				// conform to expectations, so we wrap it in a func and handle those
-				// panics by serving an error page.
+				// Create the template set.
+				// This panics if any of the funcs do not conform to expectations,
+				// so we wrap it in a func and handle those panics by serving an error page.
 				var (
-					// templateSet = amber.New(name)
-					// templateSet.Parse(s string) (*template.Template, error)
-					templateSet = template.New(name).Funcs(TemplateFuncs)
-
-					funcError *Error
+					templateSet *template.Template
+					engineErr   *Error
 				)
 
 				func() {
 					defer func() {
 						if err := recover(); err != nil {
-							funcError = &Error{
+							engineErr = &Error{
 								Title:       "Panic (Template Loader)",
 								Description: fmt.Sprintln(err),
 							}
 						}
 					}()
 
-					// If alternate delimiters set for the project, change them for this set
-					if splitDelims != nil && basePath == ViewsPath {
-						templateSet.Delims(splitDelims[0], splitDelims[1])
-					} else {
-						// Reset to default otherwise
-						templateSet.Delims("", "")
-					}
+					// TODO: shall we need config engine?
+					// // If alternate delimiters set for the project, change them for this set
+					// if splitDelims != nil && basePath == ViewsPath {
+					// 	templateSet.Delims(splitDelims[0], splitDelims[1])
+					// } else {
+					// 	// Reset to default otherwise
+					// 	templateSet.Delims("", "")
+					// }
 
-					_, err = templateSet.Parse(fileStr)
+					templateSet, err = loader.engine.Parse(templateString)
 					if err == nil {
-						loader.templateSet.AddParseTree(name, templateSet.Tree)
+						loader.AddTemplate(name, templateSet)
 					}
 				}()
 
-				if funcError != nil {
-					return funcError
+				if engineErr != nil {
+					return engineErr
 				}
 
 				return err
 			}
 
 			templateName := path[len(basePath)+1:]
-
 			// Lower case the file name for case-insensitive matching
 			lowerCaseTemplateName := strings.ToLower(templateName)
 
@@ -307,91 +351,75 @@ func (loader *TemplateLoader) Refresh() *Error {
 			err = addTemplate(lowerCaseTemplateName)
 
 			// Store / report the first error encountered.
-			if err != nil && loader.compileError == nil {
+			if err != nil && loader.engineError == nil {
 				_, line, description := parseTemplateError(err)
-				loader.compileError = &Error{
+
+				loader.engineError = &Error{
 					Title:       "Template Compilation Error",
+					Line:        line,
 					Path:        templateName,
 					Description: description,
-					Line:        line,
-					SourceLines: strings.Split(fileStr, "\n"),
+					SourceLines: strings.Split(templateString, "\n"),
 				}
-				ERROR.Printf("Template compilation error (In %s around line %d):\n%s",
-					templateName, line, description)
+
+				ERROR.Printf("Template compilation error (In %s around line %d):\n%s", templateName, line, description)
 			}
+
 			return nil
 		})
 
 		// If there was an error with the Funcs, set it and return immediately.
-		if funcErr != nil {
-			loader.compileError = funcErr.(*Error)
-			return loader.compileError
+		if walkErr != nil {
+			loader.engineError = walkErr.(*Error)
+
+			return loader.engineError
 		}
 	}
 
-	// Note: compileError may or may not be set.
-	return loader.compileError
+	// Note: engineError may or may not be set.
+	return loader.engineError
 }
 
-func (loader *TemplateLoader) WatchDir(info os.FileInfo) bool {
-	// Watch all directories, except the ones starting with a dot.
-	return !strings.HasPrefix(info.Name(), ".")
-}
-
-func (loader *TemplateLoader) WatchFile(basename string) bool {
-	// Watch all files, except the ones starting with a dot.
-	return !strings.HasPrefix(basename, ".")
-}
-
-// Parse the line, and description from an error message like:
-// html/template:Application/Register.html:36: no such template "footer.html"
-func parseTemplateError(err error) (templateName string, line int, description string) {
-	description = err.Error()
-	i := regexp.MustCompile(`:\d+:`).FindStringIndex(description)
-	if i != nil {
-		line, err = strconv.Atoi(description[i[0]+1 : i[1]-1])
-		if err != nil {
-			ERROR.Println("Failed to parse line number from error message:", err)
-		}
-		templateName = description[:i[0]]
-		if colon := strings.Index(templateName, ":"); colon != -1 {
-			templateName = templateName[colon+1:]
-		}
-		templateName = strings.TrimSpace(templateName)
-		description = description[i[1]+1:]
-	}
-	return templateName, line, description
-}
-
-// Return the Template with the given name.  The name is the template's path
-// relative to a template loader root.
+// Create a new template with the given name and associate it with the loader.
+// The name is the template's path relative to a template loader root.
 //
-// An Error is returned if there was any problem with any of the templates.  (In
-// this case, if a template is returned, it may still be usable.)
+// An error is returned if TemplateLoader has already been executed.
+func (loader *TemplateLoader) AddTemplate(name string, tmpl *template.Template) error {
+	_, err := loader.templateSet.AddParseTree(name, tmpl.Tree)
+	return err
+}
+
+// Return the Template with the given name.
+// The name is the template's path relative to a template loader root.
+//
+// An Error is returned if there was any problem with any of the templates.
+// (In this case, if a template is returned, it may still be usable.)
 func (loader *TemplateLoader) Template(name string) (Template, error) {
 	// Lower case the file name to support case-insensitive matching
 	name = strings.ToLower(name)
+
 	// Look up and return the template.
-	tmpl := loader.templateSet.Lookup(name)
+	templateSet := loader.templateSet.Lookup(name)
 
 	// This is necessary.
-	// If a nil loader.compileError is returned directly, a caller testing against
+	// If a nil loader.engineError is returned directly, a caller testing against
 	// nil will get the wrong result.  Something to do with casting *Error to error.
 	var err error
-	if loader.compileError != nil {
-		err = loader.compileError
+	if loader.engineError != nil {
+		err = loader.engineError
 	}
 
-	if tmpl == nil && err == nil {
+	if templateSet == nil && err == nil {
 		return nil, fmt.Errorf("Template %s not found.", name)
 	}
 
-	return GoTemplate{tmpl, loader}, err
+	return GoTemplate{templateSet, loader}, err
 }
 
 // Adapter for Go Templates.
 type GoTemplate struct {
 	*template.Template
+
 	loader *TemplateLoader
 }
 
@@ -405,43 +433,71 @@ func (gotmpl GoTemplate) Content() []string {
 	return content
 }
 
-/////////////////////
-// Template functions
-/////////////////////
-
-// Return a url capable of invoking a given controller method:
-// "Application.ShowApp 123" => "/app/123"
-func ReverseUrl(args ...interface{}) (string, error) {
-	if len(args) == 0 {
-		return "", fmt.Errorf("no arguments provided to reverse route")
-	}
-
-	action := args[0].(string)
-	actionSplit := strings.Split(action, ".")
-	if len(actionSplit) != 2 {
-		return "", fmt.Errorf("reversing '%s', expected 'Controller.Action'", action)
-	}
-
-	// Look up the types.
-	var c Controller
-	if err := c.SetAction(actionSplit[0], actionSplit[1]); err != nil {
-		return "", fmt.Errorf("reversing %s: %s", action, err)
-	}
-
-	// Unbind the arguments.
-	argsByName := make(map[string]string)
-	for i, argValue := range args[1:] {
-		Unbind(argsByName, c.MethodType.Args[i].Name, argValue)
-	}
-
-	return MainRouter.Reverse(args[0].(string), argsByName).Url, nil
+//////////////////////
+// Go template engine
+//////////////////////
+type GoTemplateEngine struct {
+	driver  *template.Template
+	helpers template.FuncMap
+	counter uint32
 }
 
-func Slug(text string) string {
-	separator := "-"
-	text = strings.ToLower(text)
-	text = invalidSlugPattern.ReplaceAllString(text, "")
-	text = whiteSpacePattern.ReplaceAllString(text, separator)
-	text = strings.Trim(text, separator)
-	return text
+func NewGoTemplateEngine() TemplateEnginer {
+	return &GoTemplateEngine{
+		driver:  template.New(""),
+		helpers: template.FuncMap{},
+		counter: 0,
+	}
+}
+
+func (engine *GoTemplateEngine) Parse(s string) (*template.Template, error) {
+	engine.counter += 1
+
+	return engine.driver.New(fmt.Sprintf("[#%d] GO TEMPLATE ENGINE", engine.counter)).Parse(s)
+}
+
+func (engine *GoTemplateEngine) SetHelpers(helpers template.FuncMap) {
+	for key, val := range helpers {
+		engine.helpers[key] = val
+	}
+
+	engine.driver.Funcs(helpers)
+}
+
+func (engine *GoTemplateEngine) WatchDir(dir os.FileInfo) bool {
+	// Watch all directories, except the ones starting with a dot.
+	return !strings.HasPrefix(dir.Name(), ".")
+}
+
+func (engine GoTemplateEngine) WatchFile(file string) bool {
+	// Watch all files with .html extension, except the ones starting with a dot.
+	return !strings.HasPrefix(file, ".") && strings.HasSuffix(strings.ToLower(file), ".html")
+}
+
+/////////////////////
+// Template helpers
+/////////////////////
+
+// Parse the line, and description from an error message like:
+// html/template:Application/Register.html:36: no such template "footer.html"
+func parseTemplateError(err error) (templateName string, line int, description string) {
+	description = err.Error()
+
+	i := regexp.MustCompile(`:\d+:`).FindStringIndex(description)
+	if i != nil {
+		line, err = strconv.Atoi(description[i[0]+1 : i[1]-1])
+		if err != nil {
+			ERROR.Println("Failed to parse line number from error message:", err)
+		}
+
+		templateName = description[:i[0]]
+		if colon := strings.Index(templateName, ":"); colon != -1 {
+			templateName = templateName[colon+1:]
+		}
+		templateName = strings.TrimSpace(templateName)
+
+		description = description[i[1]+1:]
+	}
+
+	return templateName, line, description
 }

--- a/template.go
+++ b/template.go
@@ -22,7 +22,7 @@ var (
 	whiteSpacePattern  = regexp.MustCompile(`\s+`)
 
 	// The default functions available for use in the templates.
-	TemplateFuncs = template.FuncMap{
+	TemplateHelpers = template.FuncMap{
 		// Return a url capable of invoking a given controller method:
 		// "Application.ShowApp 123" => "/app/123"
 		"url": func(args ...interface{}) (string, error) {
@@ -224,12 +224,12 @@ type TemplateLoader struct {
 
 func NewTemplateLoader(paths []string) *TemplateLoader {
 	enginer := NewGoTemplateEngine()
-	enginer.SetHelpers(TemplateFuncs)
+	enginer.SetHelpers(TemplateHelpers)
 
 	return &TemplateLoader{
 		engine:      enginer,
 		paths:       paths,
-		templateSet: template.New("").Funcs(TemplateFuncs),
+		templateSet: template.New("").Funcs(TemplateHelpers),
 	}
 }
 
@@ -255,7 +255,7 @@ func (loader *TemplateLoader) Refresh() *Error {
 	// Walk through the template loader's paths and build up a template set.
 	for _, basePath := range loader.paths {
 		// Walk only returns an error if the template loader is completely unusable
-		// (namely, if one of the TemplateFuncs does not have an acceptable signature).
+		// (namely, if one of the TemplateHelpers does not have an acceptable signature).
 		walkErr := filepath.Walk(basePath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				ERROR.Println("[filepath.Walk] ", path, " : ", err)

--- a/template.go
+++ b/template.go
@@ -211,7 +211,7 @@ type Template interface {
 var _TEMPLATE_ENGINERS = map[string]TemplateEnginer{}
 
 func RegisterTemplateEnginer(name string, enginer TemplateEnginer) {
-	// void overwriting
+	// avoid enginer overwriting
 	if _, ok := _TEMPLATE_ENGINERS[name]; ok {
 		return
 	}

--- a/template.go
+++ b/template.go
@@ -260,6 +260,26 @@ func NewTemplateLoader(name string, paths []string) *TemplateLoader {
 	}
 }
 
+// Config template engine with all template.* options
+// (It trims leading template. prefix when passing to engine.SetOptions())
+func (loader *TemplateLoader) SetConfig(mergedConfig *MergedConfig) {
+	templateOptions := mergedConfig.Options("template.")
+	if len(templateOptions) <= 0 {
+		return
+	}
+
+	engineConfig := config.NewDefault()
+	engineConfig.AddSection(config.DEFAULT_SECTION)
+
+	for _, option := range templateOptions {
+		optionValue, _ := mergedConfig.String(option)
+
+		engineConfig.AddOption(config.DEFAULT_SECTION, strings.TrimLeft(option, "template."), optionValue)
+	}
+
+	loader.engine.SetOptions(engineConfig)
+}
+
 // This scans the views directory and parses all templates using engine as Go Templates.
 // If a template fails to parse, the error is set on the loader.
 // (It's awkward to refresh a single Go Template)

--- a/template.go
+++ b/template.go
@@ -269,16 +269,6 @@ func (loader *TemplateLoader) Refresh() *Error {
 	loader.engineError = nil
 	loader.templatePaths = map[string]string{}
 
-	// // Set the template delimiters for the project if present, then split into left
-	// // and right delimiters around a space character
-	// var splitDelims []string
-	// if TemplateDelims != "" {
-	// 	splitDelims = strings.Split(TemplateDelims, " ")
-	// 	if len(splitDelims) != 2 {
-	// 		log.Fatalln("app.conf: Incorrect format for template.delimiters")
-	// 	}
-	// }
-
 	// Walk through the template loader's paths and build up a template set.
 	for _, basePath := range loader.paths {
 		// Walk only returns an error if the template loader is completely unusable
@@ -347,15 +337,6 @@ func (loader *TemplateLoader) Refresh() *Error {
 							}
 						}
 					}()
-
-					// TODO: shall we need config engine?
-					// // If alternate delimiters set for the project, change them for this set
-					// if splitDelims != nil && basePath == ViewsPath {
-					// 	templateSet.Delims(splitDelims[0], splitDelims[1])
-					// } else {
-					// 	// Reset to default otherwise
-					// 	templateSet.Delims("", "")
-					// }
 
 					templateSet, err = loader.engine.Parse(templateString)
 					if err == nil {
@@ -486,6 +467,18 @@ func (engine *GoTemplateEngine) Parse(s string) (*template.Template, error) {
 
 func (engine *GoTemplateEngine) SetOptions(options *config.Config) {
 	engine.options = options
+
+	// Set the template delimiters global if present,
+	// then split into left and right delimiters around a space character.
+	var splitDelims []string
+	if delims, err := engine.options.RawStringDefault("delimiters"); err == nil {
+		splitDelims = strings.Split(delims, " ")
+		if len(splitDelims) == 2 {
+			engine.driver.Delims(splitDelims[0], splitDelims[1])
+		} else {
+			engine.driver.Delims("", "")
+		}
+	}
 }
 
 func (engine *GoTemplateEngine) SetHelpers(helpers template.FuncMap) {


### PR DESCRIPTION
This pull request introduces a `TemplateEnginer` interface for easing 3d-party template parser usage. The interface defined as following:

``` go
type TemplateEnginer interface {
    Parse(s string) (*template.Template, error)
    SetOptions(options *config.Config)
    SetHelpers(helpers template.FuncMap)
    WatchDir(dir os.FileInfo) bool
    WatchFile(file string) bool
}
```

It adds a new config option of template, named `template.engine`, which used to define current template parser engine.

It also includes a helper `RegisterTemplateEngine(name string, engine TemplateEnginer)`. You _MUST_ register your engine before using it.

Now you can develop your template engine as below:

``` go
package slim

import (
    "os"
    "html/template"

    "github.com/revel/config"
    "github.com/revel/revel"
    "github.com/mcspring/slim"
)

func init() {
    revel.RegisterTemplateEngine("slim", NewSlimTemplateEngine())
}

type SlimTemplateEngine struct {
    driver *slim.Slim
    options *config.Config
}

func (engine *SlimTemplateEngine) Parse(s string) (*template.Template, error) {
    // do some slim staff
    return engine.driver.Parse(s)
}

func (engine *SlimTemplateEngine) SetOptions(options *config.Config) {
    engine.options = options
}

func (engine *SlimTemplateEngine) SetHelpers(helpers template.FuncMap) {
    engine.driver.SetHelpers(helpers)
}

func (engine *SlimTemplateEngine) WatchDir(dir os.FileInfo) bool {
    return !strings.HasPrefix(dir.Name(), ".")
}

func (engine GoTemplateEngine) WatchFile(file string) bool {
    return !strings.HasPrefix(file, ".") && strings.HasSuffix(strings.ToLower(file), ".html.slim")
}
```

Then import the engine in your app and update `app.conf` by adding:

``` ini
template.engine = slim
```

Enjoy yourself!
