### PR TITLE
Redis Cache: Save a roundtrip on delete

### DIFF
--- a/cache/redis.go
+++ b/cache/redis.go
@@ -126,10 +126,10 @@ func exists(conn redis.Conn, key string) bool {
 func (c RedisCache) Delete(key string) error {
 	conn := c.pool.Get()
 	defer conn.Close()
-	if !exists(conn, key) {
+	existed, err := redis.Bool(conn.Do("DEL", key))
+	if !existed {
 		return ErrCacheMiss
 	}
-	_, err := conn.Do("DEL", key)
 	return err
 }
 


### PR DESCRIPTION
Don't have a separate "exists" roundtrip when deleting a key, simply
read from the return value from the delete operation itself.
