### PR TITLE
Fix CI package error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - go get -v code.google.com/p/go.crypto/bcrypt
   - go get -v github.com/mattn/go-sqlite3
   - go get -v github.com/robfig/cron
-  - go get -v github.com/robfig/goauth2/oauth
+  - go get -v code.google.com/p/goauth2/oauth
   - go get -v github.com/mrjones/oauth
 script:
   - go test github.com/revel/revel


### PR DESCRIPTION
https://github.com/revel/revel/commit/5806407a57d47725b8386471febdf7f077133346 switched the facebook-oauth2 sample over to the official goauth2 location.
