### PR TITLE
skeleton gitignore tweak

### DIFF
--- a/skeleton/.gitignore
+++ b/skeleton/.gitignore
@@ -1,3 +1,3 @@
 test-results/
-tmp/
-routes/
+app/tmp/
+app/routes/


### PR DESCRIPTION
Since tmp and routes folders appear in the app folder I thought it might be worth bumping the skeleton gitignore to reflect this. Just a tiny consistency bump :)
