### PR TITLE
Setting the mail sender's name, fix issue #448

### DIFF
--- a/mail/connection.go
+++ b/mail/connection.go
@@ -108,16 +108,5 @@ func extractAddress(from string) string {
 		return strings.Trim(addr, " ")
 	}
 
-	//if using html entities...	
-	i = strings.Index(from, "&lt;")
-	if i > -1 {
-		addr := from[i:]
-		addr = strings.Replace(addr, "&lt;", "", -1)
-		addr = strings.Replace(addr, "&gt;", "", -1)
-		return strings.Trim(addr, " ")
-	}
-
-	//none of them...
 	return from
 }
-


### PR DESCRIPTION
Hi! 

Gmail appears to be not accepting characters like "<" and ">" into the 'From' field (at the Send method).

However, gmail accepts the syntax `From: SOME NAME <SOME@MAIL.COM>` at message body.  

So the fix is just send only the email(without alias and special chars) at Send method.
