### PR TITLE
Add "X-HTTP-Method-Override" to router

### DIFF
--- a/router.go
+++ b/router.go
@@ -93,7 +93,7 @@ var notFound = &RouteMatch{Action: "404"}
 
 func (router *Router) Route(req *http.Request) *RouteMatch {
 	// Override method if set in header
-	if method := req.Header.Get("X-HTTP-Method-Override"); method != "" {
+	if method := req.Header.Get("X-HTTP-Method-Override"); method != "" && req.Method == "POST" {
 		req.Method = method
 	}
 

--- a/router_test.go
+++ b/router_test.go
@@ -199,22 +199,28 @@ var routeMatchTestCases = map[*http.Request]*RouteMatch{
 		FixedParams:    []string{},
 		Params:         map[string][]string{},
 	},
-}
 
-func init() {
-	methodOverrideTestRequest := &http.Request{
+	&http.Request{
 		Method: "POST",
 		URL:    &url.URL{Path: "/app/123"},
-		Header: make(http.Header),
-	}
-
-	methodOverrideTestRequest.Header.Add("X-HTTP-Method-Override", "PATCH")
-	routeMatchTestCases[methodOverrideTestRequest] = &RouteMatch{
+		Header: http.Header{"X-Http-Method-Override": []string{"PATCH"}},
+	}: &RouteMatch{
 		ControllerName: "Application",
 		MethodName:     "Update",
 		FixedParams:    []string{},
 		Params:         map[string][]string{"id": {"123"}},
-	}
+	},
+
+	&http.Request{
+		Method: "GET",
+		URL:    &url.URL{Path: "/app/123"},
+		Header: http.Header{"X-Http-Method-Override": []string{"PATCH"}},
+	}: &RouteMatch{
+		ControllerName: "Application",
+		MethodName:     "Show",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
 }
 
 func TestRouteMatches(t *testing.T) {


### PR DESCRIPTION
Cleaned up version of @klauspost's #639.

<hr>

This will add X-HTTP-Method-Override as a method override to the router.
The request method is replaced, so subsequent filters can test on the
intended method.

This should make it safe for CSRF testing, since the CSRF filter will
see the intended method and not the actual used one.

Test added. I found no way to declare the headers inline, so it has to
be added in code.
