### PR TITLE
Update the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,8 +122,8 @@ To develop the Jekyll site locally:
     $ git clone git@github.com:revel/revel.github.io
     $ cd revel.github.io
 
-    # Install / run Jekyll to generate the site, and serve the result
-    $ gem install jekyll
+    # Install and run Jekyll to generate and serve the site
+    $ gem install jekyll kramdown
     $ jekyll serve --watch
 
     # Now load in your browser


### PR DESCRIPTION
This fixes the instructions for how to edit the documentation, and tweaks some of the wording in the contributing doc.

Also adds a link to https://code.google.com/p/go-wiki/wiki/CodeReviewComments, which is something I think all Go projects should adopt.
