### PR TITLE
Case insensitive comparison for websocket upgrades (Fixes IE Websockets ...

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -70,7 +70,7 @@ func (hp *Harness) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Reverse proxy the request.
 	// (Need special code for websockets, courtesy of bradfitz)
-	if r.Header.Get("Upgrade") == "websocket" {
+	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
 		proxyWebsocket(w, r, hp.serverHost)
 	} else {
 		hp.proxy.ServeHTTP(w, r)


### PR DESCRIPTION
...not passing through)

Internet Explorer users "Websocket" (with a capital W) in contrast to most, so websockets from IE are not upgraded when using the reverse proxy.

The check in "server.go" is fine.
