### PR TITLE
[RETARGET] http testing support for HTTP PUT & PATCH

### DIFF
--- a/tests.go
+++ b/tests.go
@@ -87,6 +87,28 @@ func (t *TestSuite) Post(path string, contentType string, reader io.Reader) {
 	t.MakeRequestSession(req)
 }
 
+//Issue a PUT request to the given path, sending the given Content-Type and
+// data, and store the result in Request and RequestBody.  "data" may be nil.
+func (t *TestSuite) Put(path string, contentType string, reader io.Reader) {
+	req, err := http.NewRequest("PUT", t.BaseUrl()+path, reader)
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	t.MakeRequestSession(req)
+}
+
+// Issue a PATCH request to the given path, sending the given Content-Type and
+// data, and store the result in Request and RequestBody.  "data" may be nil.
+func (t *TestSuite) Patch(path string, contentType string, reader io.Reader) {
+	req, err := http.NewRequest("PATCH", t.BaseUrl()+path, reader)
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	t.MakeRequestSession(req)
+}
+
 // Issue a POST request to the given path as a form post of the given key and
 // values, and store the result in Request and RequestBody.
 func (t *TestSuite) PostForm(path string, data url.Values) {


### PR DESCRIPTION
It would be good if you could add support for the PUT & PATCH HTTP methods into revel testing.
