### PR TITLE
Add log.colorize option to enable/disable colorize

### DIFF
--- a/revel.go
+++ b/revel.go
@@ -187,7 +187,7 @@ func Init(mode, importPath, srcPath string) {
 	}
 
 	// Configure logging
-	if Config.BoolDefault("log.colorize", true) {
+	if !Config.BoolDefault("log.colorize", true) {
 		gocolorize.SetPlain(true)
 	}
 


### PR DESCRIPTION
I would like to log without color on my production environment, so I made this pull request.
What do you think?
