### PR TITLE
[RETARGET] Better error parsing and using subl-handler

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package revel
 import (
 	"fmt"
 	"runtime/debug"
+	"strconv"
 	"strings"
 )
 
@@ -14,6 +15,7 @@ type Error struct {
 	SourceLines              []string // The entire source file, split into lines.
 	Stack                    string   // The raw stack trace string from debug.Stack().
 	MetaError                string   // Error that occurred producing the error page.
+	Link                     string   // A configurable link to wrap the error source in
 }
 
 // An object to hold the per-source-line details.
@@ -114,4 +116,11 @@ func findRelevantStackFrame(stack string) (int, string) {
 		}
 	}
 	return -1, ""
+}
+
+func (e *Error) SetLink(fLink string) {
+	fLink = strings.Replace(fLink, "{{Path}}", e.Path, -1)
+	fLink = strings.Replace(fLink, "{{Line}}", strconv.Itoa(e.Line), -1)
+
+	e.Link = "<a href=" + fLink + ">" + e.Path + ":" + strconv.Itoa(e.Line) + "</a>"
 }

--- a/harness/build.go
+++ b/harness/build.go
@@ -283,6 +283,12 @@ func newCompileError(output []byte) *revel.Error {
 		}
 	)
 
+	fLink := revel.Config.StringDefault("error.link", "")
+
+	if fLink != "" {
+		compileError.SetLink(fLink)
+	}
+
 	fileStr, err := revel.ReadLines(absFilename)
 	if err != nil {
 		compileError.MetaError = absFilename + ": " + err.Error()

--- a/harness/reflect.go
+++ b/harness/reflect.go
@@ -130,6 +130,13 @@ func ProcessSource(roots []string) (*SourceInfo, *revel.Error) {
 						Column:      pos.Column,
 						SourceLines: revel.MustReadLines(pos.Filename),
 					}
+
+					fLink := revel.Config.StringDefault("error.link", "")
+
+					if fLink != "" {
+						compileError.SetLink(fLink)
+					}
+
 					return compileError
 				}
 				ast.Print(nil, err)

--- a/templates/errors/500-dev.html
+++ b/templates/errors/500-dev.html
@@ -88,7 +88,13 @@
 				{{if .SourceType}}
 					The {{.SourceType}}
 					{{if .Path }}
-						<strong><a href="subl://open?url=file://{{.Path}}&amp;line={{.Line}}">{{.Path}}:{{.Line}}</a></strong>
+						<strong>
+						{{if .Link}}
+							{{raw .Link}}
+						{{else}}
+							{{.Path}}:{{.Line}}
+						{{end}}
+						</strong>
 					{{end}}
 					does not compile: <strong>{{.Description}}</strong>
 				{{else}}


### PR DESCRIPTION
Hey, I was getting frustrated at some of the error reporting so I decided to see what I could do to improve it. Some errors would not come up on the page, usually ones that were not syntax errors but stuff like trying to access a field on a struct that didn't exist or initializing a variable that is never used.

Additionally, the coolest part is I now make use of [subl-handler](https://github.com/ktunkiewicz/subl-handler) which allows you to click a link to open a file in various editors at the specified line. It supports the subl:// URL handler for which there are versions on various platforms, not just Windows.

The result is this:
![Error reporting](http://i.imgur.com/aGHpXAs.png)

When you click on the link, provided you have a subl:// handler installed, it'll take you directly to the file on the line giving the error.
