### PR TITLE
Revert "Better error parsing and using subl-handler"

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,6 @@ package revel
 import (
 	"fmt"
 	"runtime/debug"
-	"strconv"
 	"strings"
 )
 
@@ -15,7 +14,6 @@ type Error struct {
 	SourceLines              []string // The entire source file, split into lines.
 	Stack                    string   // The raw stack trace string from debug.Stack().
 	MetaError                string   // Error that occurred producing the error page.
-	Link                     string   // A configurable link to wrap the error source in
 }
 
 // An object to hold the per-source-line details.
@@ -116,11 +114,4 @@ func findRelevantStackFrame(stack string) (int, string) {
 		}
 	}
 	return -1, ""
-}
-
-func (e *Error) SetLink(fLink string) {
-	fLink = strings.Replace(fLink, "{{Path}}", e.Path, -1)
-	fLink = strings.Replace(fLink, "{{Line}}", strconv.Itoa(e.Line), -1)
-
-	e.Link = "<a href=" + fLink + ">" + e.Path + ":" + strconv.Itoa(e.Line) + "</a>"
 }

--- a/harness/build.go
+++ b/harness/build.go
@@ -2,6 +2,7 @@ package harness
 
 import (
 	"fmt"
+	"github.com/revel/revel"
 	"go/build"
 	"os"
 	"os/exec"
@@ -12,8 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
-
-	"github.com/revel/revel"
 )
 
 var importErrorPattern = regexp.MustCompile("cannot find package \"([^\"]+)\"")
@@ -252,20 +251,12 @@ func newCompileError(output []byte) *revel.Error {
 	errorMatch := regexp.MustCompile(`(?m)^([^:#]+):(\d+):(\d+:)? (.*)$`).
 		FindSubmatch(output)
 	if errorMatch == nil {
-		errorMatch = regexp.MustCompile(`(?m)^(.*?)\:(\d+)\:\s(.*?)$`).FindSubmatch(output)
-
-		if errorMatch == nil {
-			revel.ERROR.Println("Failed to parse build errors:\n", string(output))
-			return &revel.Error{
-				SourceType:  "Go code",
-				Title:       "Go Compilation Error",
-				Description: "See console for build error.",
-			}
+		revel.ERROR.Println("Failed to parse build errors:\n", string(output))
+		return &revel.Error{
+			SourceType:  "Go code",
+			Title:       "Go Compilation Error",
+			Description: "See console for build error.",
 		}
-
-		errorMatch = append(errorMatch, errorMatch[3])
-
-		revel.ERROR.Println("Build errors:\n", string(output))
 	}
 
 	// Read the source for the offending file.
@@ -282,12 +273,6 @@ func newCompileError(output []byte) *revel.Error {
 			Line:        line,
 		}
 	)
-
-	fLink := revel.Config.StringDefault("error.link", "")
-
-	if fLink != "" {
-		compileError.SetLink(fLink)
-	}
 
 	fileStr, err := revel.ReadLines(absFilename)
 	if err != nil {

--- a/harness/reflect.go
+++ b/harness/reflect.go
@@ -130,13 +130,6 @@ func ProcessSource(roots []string) (*SourceInfo, *revel.Error) {
 						Column:      pos.Column,
 						SourceLines: revel.MustReadLines(pos.Filename),
 					}
-
-					fLink := revel.Config.StringDefault("error.link", "")
-
-					if fLink != "" {
-						compileError.SetLink(fLink)
-					}
-
 					return compileError
 				}
 				ast.Print(nil, err)

--- a/templates/errors/500-dev.html
+++ b/templates/errors/500-dev.html
@@ -86,17 +86,7 @@
 			</h1>
 			<p>
 				{{if .SourceType}}
-					The {{.SourceType}}
-					{{if .Path }}
-						<strong>
-						{{if .Link}}
-							{{raw .Link}}
-						{{else}}
-							{{.Path}}:{{.Line}}
-						{{end}}
-						</strong>
-					{{end}}
-					does not compile: <strong>{{.Description}}</strong>
+					The {{.SourceType}} <strong>{{.Path}}</strong> does not compile: <strong>{{.Description}}</strong>
 				{{else}}
 					{{.Description}}
 				{{end}}


### PR DESCRIPTION
Reverts revel/revel#719

I'm silly. I wasn't paying attention to the targeted branch. Needs to target `develop`
