### PR TITLE
watcher: treat fsnotify Op as a bitmask

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -214,7 +214,7 @@ func (w *Watcher) rebuildRequired(ev fsnotify.Event, listener Listener) bool {
 	}
 
 	if dl, ok := listener.(DiscerningListener); ok {
-		if !dl.WatchFile(ev.Name) || ev.Op == fsnotify.Chmod {
+		if !dl.WatchFile(ev.Name) || ev.Op&fsnotify.Chmod == fsnotify.Chmod {
 			return false
 		}
 	}


### PR DESCRIPTION
Thanks for updating to fsnotify.v1.

I think this is the behaviour you would want if multiple Ops are set.

tracking ref https://github.com/go-fsnotify/fsnotify/issues/35
