### PR TITLE
Redis Cache: Add timeouts.

### DIFF
--- a/cache/redis.go
+++ b/cache/redis.go
@@ -20,7 +20,10 @@ func NewRedisCache(host string, password string, defaultExpiration time.Duration
 		IdleTimeout: time.Duration(revel.Config.IntDefault("cache.redis.idletimeout", 240)) * time.Second,
 		Dial: func() (redis.Conn, error) {
 			protocol := revel.Config.StringDefault("cache.redis.protocol", "tcp")
-			c, err := redis.Dial(protocol, host)
+			toc := time.Millisecond * time.Duration(revel.Config.IntDefault("cache.redis.timeout.connect", 10000))
+			tor := time.Millisecond * time.Duration(revel.Config.IntDefault("cache.redis.timeout.read", 5000))
+			tow := time.Millisecond * time.Duration(revel.Config.IntDefault("cache.redis.timeout.write", 5000))
+			c, err := redis.DialTimeout(protocol, host, toc, tor, tow)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This enables you to have configurable timeouts on redis. With the current implementation cache requests might hang indefinitely. This enables you to have fallback to things like a database lookup.

This adds "cache.redis.timeout.connect", "cache.redis.timeout.read" and "cache.redis.timeout.write" variables. Value is in milliseconds, since you might want sub-second timeouts.

Defaults are 10 second for connect, 5 second for read/writes which is very high, so people "relying" on a reliable cache can continue to do so.
