### PR TITLE
Errors on templates with all-lowercase filenames are not reported.

### DIFF
--- a/template.go
+++ b/template.go
@@ -343,7 +343,9 @@ func (loader *TemplateLoader) Refresh() *Error {
 			lowerCaseTemplateName := strings.ToLower(templateName)
 
 			err = addTemplate(templateName)
-			err = addTemplate(lowerCaseTemplateName)
+			if err == nil {
+				err = addTemplate(lowerCaseTemplateName)
+			}
 
 			// Store / report the first error encountered.
 			if err != nil && loader.compileError == nil {


### PR DESCRIPTION
Long story: if addTemplate(templateName) fails the error is overwritten with the result from addTemplate(lowerCaseTemplateName). However, if the lower case name is the same as the filename, the function returns early without error at

``` go
if _, ok := loader.templatePaths[templateName]; ok {
  return nil
}
```
