### PR TITLE
Add i18n templates.

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -103,9 +103,12 @@ func (c *Controller) Render(extraRenderArgs ...interface{}) Result {
 // A less magical way to render a template.
 // Renders the given template, using the current RenderArgs.
 func (c *Controller) RenderTemplate(templatePath string) Result {
+	// Get Language
+	// We ignore if cast is unsuccessful, since it will give us an empty string anyway.
+	lang, _ := c.RenderArgs[CurrentLocaleRenderArg].(string)
 
 	// Get the Template.
-	template, err := MainTemplateLoader.Template(templatePath)
+	template, err := MainTemplateLoader.TemplateLang(templatePath, lang)
 	if err != nil {
 		return c.RenderError(err)
 	}

--- a/results.go
+++ b/results.go
@@ -40,10 +40,14 @@ func (r ErrorResult) Apply(req *Request, resp *Response) {
 		contentType = "text/plain"
 	}
 
+	// Get Language
+	// We ignore if cast is unsuccessful, since it will give us an empty string anyway.
+	lang, _ := r.RenderArgs[CurrentLocaleRenderArg].(string)
+
 	// Get the error template.
 	var err error
 	templatePath := fmt.Sprintf("errors/%d.%s", status, format)
-	tmpl, err := MainTemplateLoader.Template(templatePath)
+	tmpl, err := MainTemplateLoader.TemplateLang(templatePath, lang)
 
 	// This func shows a plaintext error message, in case the template rendering
 	// doesn't work.
@@ -173,7 +177,11 @@ func (r *RenderTemplateResult) render(req *Request, resp *Response, wr io.Writer
 		templateName = r.Template.Name()
 		templateContent = r.Template.Content()
 	} else {
-		if tmpl, err := MainTemplateLoader.Template(templateName); err == nil {
+		// Get Language
+		// We ignore if cast is unsuccessful, since it will give us an empty string anyway.
+		lang, _ := r.RenderArgs[CurrentLocaleRenderArg].(string)
+
+		if tmpl, err := MainTemplateLoader.TemplateLang(templateName, lang); err == nil {
 			templateContent = tmpl.Content()
 		}
 	}


### PR DESCRIPTION
All templates can now have an optional language suffix. The loader will attempt to load a template with the language specified language as an extension to the specified name. For instance "index.html" with "en" as language will attempt to load "index.html.en" first, and fall back to "template.html" if the file cannot be found.

Internationalized templates can also be dynamically included in the templates. To do this, use a the template function {{ i18ntemplate . "included.html" }}

This function will also attempt to load "included.html.en" if the language is English, and will fall back to including "included.html" if the language cannot be found.
