### PR TITLE
Changes c.Action to be the action method name's letter casing per #635

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -249,7 +249,7 @@ func (c *Controller) SetAction(controllerName, methodName string) error {
 		return errors.New("revel/controller: failed to find action " + methodName)
 	}
 
-	c.Name, c.MethodName = c.Type.Type.Name(), methodName
+	c.Name, c.MethodName = c.Type.Type.Name(), c.MethodType.Name
 	c.Action = c.Name + "." + c.MethodName
 
 	// Instantiate the controller.


### PR DESCRIPTION
#635

My proposed TODOs weren't needed. Simple tweak.
