### PR TITLE
Fixing cross-compiling issue #456 setting windows path from linux

### DIFF
--- a/harness/build.go
+++ b/harness/build.go
@@ -62,7 +62,13 @@ func Build() (app *App, compileError *revel.Error) {
 		revel.ERROR.Fatalln("Failure importing", revel.ImportPath)
 	}
 	binName := path.Join(pkg.BinDir, path.Base(revel.BasePath))
-	if runtime.GOOS == "windows" {
+
+	// Change binary path for Windows build
+	goos := runtime.GOOS
+	if goosEnv := os.Getenv("GOOS"); goosEnv != "" {
+		goos = goosEnv
+	}
+	if goos == "windows" {
 		binName += ".exe"
 	}
 


### PR DESCRIPTION
This fixes #456 by giving priority to os.Getenv("GOOS") (when defined) over runtime.GOOS. Couldn't fully test the changes against develop because of #747, but did manual tests against master.
