### PR TITLE
i18n: Make Message Translation plugable

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -233,7 +233,7 @@ func (c *Controller) Redirect(val interface{}, args ...interface{}) Result {
 //
 // The current language is set by the i18n plugin.
 func (c *Controller) Message(message string, args ...interface{}) (value string) {
-	return Message(c.Request.Locale, message, args...)
+	return MessageFunc(c.Request.Locale, message, args...)
 }
 
 // SetAction sets the action that is being invoked in the current request.

--- a/i18n.go
+++ b/i18n.go
@@ -24,6 +24,14 @@ var (
 	messages map[string]*config.Config
 )
 
+// Setting MessageFunc allows you to override the translation interface.
+//
+// Set this to your own function that translates to the current locale.
+// This allows you to set up your own loading and logging of translated texts.
+//
+// See Message(...) in i18n.go for example of function.
+var MessageFunc func(locale, message string, args ...interface{}) (value string) = Message
+
 // Return all currently loaded message languages.
 func MessageLanguages() []string {
 	languages := make([]string, len(messages))

--- a/template.go
+++ b/template.go
@@ -124,7 +124,7 @@ var (
 			if !ok {
 				return ""
 			}
-			return template.HTML(Message(str, message, args...))
+			return template.HTML(MessageFunc(str, message, args...))
 		},
 
 		// Replaces newlines with <br>


### PR DESCRIPTION
This allows users to override the Message function in revel with their
own. It defaults to the existing Message function, so there should be no
compatibility issues.