### PR TITLE
Fix travis for 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 install:
   - export PATH=$PATH:$HOME/gopath/bin
   - export REVEL_BRANCH="develop"
-  - '[[ "$TRAVIS_BRANCH" == "master" ]] && export REVEL_BRANCH="master"'
+  - 'if [[ "$TRAVIS_BRANCH" == "master" ]]; then export REVEL_BRANCH="master"; fi'
   - 'echo "Travis branch: $TRAVIS_BRANCH, Revel dependency branch: $REVEL_BRANCH"'
   - go get -v github.com/revel/revel/...
   - git clone -b $REVEL_BRANCH git://github.com/revel/modules ../modules/


### PR DESCRIPTION
Fixes #787

The dynamic branch switching is rather shitty, as there is now no way to run CI for PRs against master. The only way of fixing this I can think of is to have a file similar to a Gemfile.lock that records the SHA of the referenced repos :(
