### PR TITLE
Fix for static module files

### DIFF
--- a/modules/static/app/controllers/static.go
+++ b/modules/static/app/controllers/static.go
@@ -49,6 +49,9 @@ func (c Static) Serve(prefix, filepath string) revel.Result {
 		return c.NotFound("")
 	}
 
+	return serve(c, prefix, filepath)
+}
+func serve(c Static, prefix, filepath string) revel.Result {
 	var basePath string
 	if !fpath.IsAbs(prefix) {
 		basePath = revel.BasePath
@@ -107,5 +110,5 @@ func (c Static) ServeModule(moduleName, prefix, filepath string) revel.Result {
 
 	absPath := fpath.Join(basePath, fpath.FromSlash(prefix))
 
-	return c.Serve(absPath, filepath)
+	return serve(c, absPath, filepath)
 }


### PR DESCRIPTION
Getting the prefix from fixed parameters was overriding the absPath and
causing 404 on static files for modules (e.g. testrunner)