### PR TITLE
Added i18n setting for unknown message value format.

### DIFF
--- a/i18n.go
+++ b/i18n.go
@@ -12,11 +12,12 @@ import (
 const (
 	CurrentLocaleRenderArg = "currentLocale" // The key for the current locale render arg value
 
-	messageFilesDirectory = "messages"
-	messageFilePattern    = `^\w+\.[a-zA-Z]{2}$`
-	unknownValueFormat    = "??? %s ???"
-	defaultLanguageOption = "i18n.default_language"
-	localeCookieConfigKey = "i18n.cookie"
+	messageFilesDirectory  = "messages"
+	messageFilePattern     = `^\w+\.[a-zA-Z]{2}$`
+	defaultUnknownFormat   = "??? %s ???"
+	unknownFormatConfigKey = "i18n.unknown_format"
+	defaultLanguageOption  = "i18n.default_language"
+	localeCookieConfigKey  = "i18n.cookie"
 )
 
 var (
@@ -40,6 +41,7 @@ func MessageLanguages() []string {
 // When either an unknown locale or message is detected, a specially formatted string is returned.
 func Message(locale, message string, args ...interface{}) string {
 	language, region := parseLocale(locale)
+	unknownValueFormat := getUnknownValueFormat()
 
 	messageConfig, knownLanguage := messages[language]
 	if !knownLanguage {
@@ -82,6 +84,11 @@ func parseLocale(locale string) (language, region string) {
 	}
 
 	return locale, ""
+}
+
+// Retrieve message format or default format when i18n message is missing.
+func getUnknownValueFormat() string {
+	return Config.StringDefault(unknownFormatConfigKey, defaultUnknownFormat)
 }
 
 // Recursively read and cache all available messages from all message files on the given path.

--- a/i18n_test.go
+++ b/i18n_test.go
@@ -132,6 +132,24 @@ func TestBeforeRequest(t *testing.T) {
 	}
 }
 
+func TestI18nMessageUnknownValueFormat(t *testing.T) {
+	loadMessages(testDataPath)
+	loadTestI18nConfigWithUnknowFormatOption(t)
+
+	// Assert that we can get a message and we get the expected return value
+	if message := Message("en", "greeting"); message != "Hello" {
+		t.Errorf("Message 'greeting' for locale 'en' (%s) does not have the expected value", message)
+	}
+
+	// Assert that we get the expected return value with original format
+	if message := Message("unknown locale", "message"); message != "*** message ***" {
+		t.Error("Locale 'unknown locale' is not supposed to exist")
+	}
+	if message := Message("nl", "unknown message"); message != "*** unknown message ***" {
+		t.Error("Message 'unknown message' is not supposed to exist")
+	}
+}
+
 func BenchmarkI18nLoadMessages(b *testing.B) {
 	excludeFromTimer(b, func() { TRACE = log.New(ioutil.Discard, "", 0) })
 
@@ -182,6 +200,11 @@ func loadTestI18nConfig(t *testing.T) {
 func loadTestI18nConfigWithoutLanguageCookieOption(t *testing.T) {
 	loadTestI18nConfig(t)
 	Config.config.RemoveOption("DEFAULT", "i18n.cookie")
+}
+
+func loadTestI18nConfigWithUnknowFormatOption(t *testing.T) {
+	loadTestI18nConfig(t)
+	Config.config.AddOption("DEFAULT", "i18n.unknown_format", "*** %s ***")
 }
 
 func buildRequestWithCookie(name, value string) *Request {

--- a/skeleton/conf/app.conf.template
+++ b/skeleton/conf/app.conf.template
@@ -86,6 +86,10 @@ log.error.prefix = "ERROR "
 # The default language of this application.
 i18n.default_language = en
 
+# The default format when message is missing.
+# The original message shows in %s
+#i18n.unknown_format = "??? %s ???"
+
 
 # Module to serve static content such as CSS, JavaScript and Media files
 # Allows Routes like this:


### PR DESCRIPTION
i18n message has default format when the message is missing in message files.
It was defined as constants value `??? %s ???`. 
But it should be changeable especially on the production environment.

This function will attempt to allow revel's users to change the format in the config file.
The new config option name is `i18n.unknown_format`.