### PR TITLE
[RETARGET] Fixed router app start bug without routes.

### DIFF
--- a/router.go
+++ b/router.go
@@ -425,8 +425,9 @@ func init() {
 		MainRouter = NewRouter(path.Join(BasePath, "conf", "routes"))
 		if MainWatcher != nil && Config.BoolDefault("watch.routes", true) {
 			MainWatcher.Listen(MainRouter, MainRouter.path)
-		} else {
-			MainRouter.Refresh()
+		} else if err := MainRouter.Refresh(); err != nil {
+			// Not in dev mode and Route loading failed, we should crash.
+			ERROR.Panicln(err.Error())
 		}
 	})
 }


### PR DESCRIPTION
App doesn't crash when it doesn't have any routes to serve, and the
returned error is discarded, not checked. This checks if the error is
not nil and crashes if it should because no routes means nothing to do.