### PR TITLE
Adds debug code to reproduce websocket connection timeout issue

### DIFF
--- a/server.go
+++ b/server.go
@@ -25,12 +25,8 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	upgrade := r.Header.Get("Upgrade")
 	if upgrade == "websocket" || upgrade == "Websocket" {
 		websocket.Handler(func(ws *websocket.Conn) {
-			ws.SetDeadline(time.Now().Add(time.Second * 10))
-			var msg = make([]byte, 512)
-			if _, err := ws.Read(msg); err != nil {
-				ERROR.Println(err)
-			}
-			WARN.Println(time.Now(), string(msg))
+			//Override default Read/Write timeout with sane value for a web socket request
+			ws.SetDeadline(time.Now().Add(time.Hour * 24))
 			r.Method = "WS"
 			handleInternal(w, r, ws)
 		}).ServeHTTP(w, r)

--- a/server.go
+++ b/server.go
@@ -25,6 +25,12 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	upgrade := r.Header.Get("Upgrade")
 	if upgrade == "websocket" || upgrade == "Websocket" {
 		websocket.Handler(func(ws *websocket.Conn) {
+			ws.SetDeadline(time.Now().Add(time.Second * 10))
+			var msg = make([]byte, 512)
+			if _, err := ws.Read(msg); err != nil {
+				ERROR.Println(err)
+			}
+			WARN.Println(time.Now(), string(msg))
 			r.Method = "WS"
 			handleInternal(w, r, ws)
 		}).ServeHTTP(w, r)


### PR DESCRIPTION
Bug introduced by #843. See its thread for more details.

## TODO
- [x] ~~Ideally, we want to extend the deadline for each websocket frame, [just like the `net/http` server does](http://golang.org/src/net/http/server.go?s=47492:48985#L575), but I'm not sure the best way to accomplish this. It seems the [websocket `Codec`](http://godoc.org/golang.org/x/net/websocket#Codec) may be the proper place to do this.~~

The app can extend the deadline for each message received without Revel's help. A sane deadline of 24 hours is set by default for WS requests now.