### PR TITLE
Map to index action of controllers when no action is specified.

### DIFF
--- a/skeleton/conf/routes
+++ b/skeleton/conf/routes
@@ -12,5 +12,8 @@ GET     /favicon.ico                            404
 # Map static resources from the /app/public folder to the /public path
 GET     /public/*filepath                       Static.Serve("public")
 
+# Map to index action of controllers by default when no action is specified
+GET     /:controller/                           :controller.index
+
 # Catch all
 *       /:controller/:action                    :controller.:action


### PR DESCRIPTION
 I figured other people would want the ability to route to index action of controller by default when none is provided.