### PR TITLE
Add a symlink-aware filepath.Walk helper

### DIFF
--- a/i18n.go
+++ b/i18n.go
@@ -2,11 +2,12 @@ package revel
 
 import (
 	"fmt"
-	"github.com/robfig/config"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/robfig/config"
 )
 
 const (
@@ -88,7 +89,7 @@ func parseLocale(locale string) (language, region string) {
 func loadMessages(path string) {
 	messages = make(map[string]*config.Config)
 
-	if error := filepath.Walk(path, loadMessageFile); error != nil && !os.IsNotExist(error) {
+	if error := Walk(path, loadMessageFile); error != nil && !os.IsNotExist(error) {
 		ERROR.Println("Error reading messages files:", error)
 	}
 }

--- a/template.go
+++ b/template.go
@@ -228,33 +228,6 @@ func (loader *TemplateLoader) Refresh() *Error {
 				return nil
 			}
 
-			// is it a symlinked template?
-			link, err := os.Lstat(path)
-			if err == nil && link.Mode()&os.ModeSymlink == os.ModeSymlink {
-				TRACE.Println("symlink template:", path)
-				// lookup the actual target & check for goodness
-				targetPath, err := filepath.EvalSymlinks(path)
-				if err != nil {
-					ERROR.Println("Failed to read symlink", err)
-					return err
-				}
-				targetInfo, err := os.Stat(targetPath)
-				if err != nil {
-					ERROR.Println("Failed to stat symlink target", err)
-					return err
-				}
-
-				// set the template path to the target of the symlink
-				path = targetPath
-				info = targetInfo
-
-				// need to save state and restore for recursive call to Walk on symlink
-				tmp := fullSrcDir
-				fullSrcDir = filepath.Dir(targetPath)
-				filepath.Walk(targetPath, templateWalker)
-				fullSrcDir = tmp
-			}
-
 			// Walk into watchable directories
 			if info.IsDir() {
 				if !loader.WatchDir(info) {
@@ -356,7 +329,7 @@ func (loader *TemplateLoader) Refresh() *Error {
 			return nil
 		}
 
-		funcErr := filepath.Walk(fullSrcDir, templateWalker)
+		funcErr := Walk(fullSrcDir, templateWalker)
 
 		// If there was an error with the Funcs, set it and return immediately.
 		if funcErr != nil {

--- a/watcher.go
+++ b/watcher.go
@@ -1,12 +1,13 @@
 package revel
 
 import (
-	"gopkg.in/fsnotify.v1"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"gopkg.in/fsnotify.v1"
 )
 
 // Listener is an interface for receivers of filesystem events.
@@ -90,28 +91,6 @@ func (w *Watcher) Listen(listener Listener, roots ...string) {
 				return nil
 			}
 
-			// is it a symlinked template?
-			link, err := os.Lstat(path)
-			if err == nil && link.Mode()&os.ModeSymlink == os.ModeSymlink {
-				TRACE.Println("Watcher symlink: ", path)
-				// lookup the actual target & check for goodness
-				targetPath, err := filepath.EvalSymlinks(path)
-				if err != nil {
-					ERROR.Println("Failed to read symlink", err)
-					return err
-				}
-				targetInfo, err := os.Stat(targetPath)
-				if err != nil {
-					ERROR.Println("Failed to stat symlink target", err)
-					return err
-				}
-
-				// set the template path to the target of the symlink
-				path = targetPath
-				info = targetInfo
-				filepath.Walk(path, watcherWalker)
-			}
-
 			if info.IsDir() {
 				if dl, ok := listener.(DiscerningListener); ok {
 					if !dl.WatchDir(info) {
@@ -128,7 +107,7 @@ func (w *Watcher) Listen(listener Listener, roots ...string) {
 		}
 
 		// Else, walk the directory tree.
-		filepath.Walk(p, watcherWalker)
+		Walk(p, watcherWalker)
 	}
 
 	if w.eagerRebuildEnabled() {


### PR DESCRIPTION
This adds a symlink-aware filepath.Walk helper to unify all the code which needs this functionality in revel.
It fixes #673 and an according pull request for revel/cmd is here: https://github.com/revel/cmd/pull/20.

I tested it with a new app, symlinked the whole folder into another directory (my original use-case) and symlinked some static files around. Everything worked as expected, revel still found all the files and the app built and ran fine.