### PR TITLE
Wildcard reverse routing parameter patch

### DIFF
--- a/router.go
+++ b/router.go
@@ -375,7 +375,7 @@ func (router *Router) Reverse(action string, argValues map[string]string) *Actio
 			pathElements = strings.Split(route.Path, "/")
 		)
 		for i, el := range pathElements {
-			if el == "" || el[0] != ':' {
+			if el == "" || (el[0] != ':' && el[0] != '*' ) {
 				continue
 			}
 


### PR DESCRIPTION
This resolves issue #869 . Revel incorrectly would append a parameter to a route path with a wild card (like /foo/*bar) in it.