### PR TITLE
Optimize search of template names

### DIFF
--- a/template.go
+++ b/template.go
@@ -29,6 +29,8 @@ type TemplateLoader struct {
 	paths []string
 	// Map from template name to the path from whence it was loaded.
 	templatePaths map[string]string
+	// templateNames is a map from lower case template name to the real template name.
+	templateNames map[string]string
 }
 
 type Template interface {
@@ -192,6 +194,7 @@ func (loader *TemplateLoader) Refresh() *Error {
 
 	loader.compileError = nil
 	loader.templatePaths = map[string]string{}
+	loader.templateNames = map[string]string{}
 
 	// Set the template delimiters for the project if present, then split into left
 	// and right delimiters around a space character
@@ -279,11 +282,13 @@ func (loader *TemplateLoader) Refresh() *Error {
 				}
 
 				// If we already loaded a template of this name, skip it.
-				if _, ok := loader.templatePaths[templateName]; ok {
+				lowerTemplateName := strings.ToLower(templateName)
+				if _, ok := loader.templateNames[lowerTemplateName]; ok {
 					return nil
 				}
 
 				loader.templatePaths[templateName] = path
+				loader.templateNames[lowerTemplateName] = templateName
 
 				// Load the file if we haven't already
 				if fileStr == "" {
@@ -407,14 +412,10 @@ func parseTemplateError(err error) (templateName string, line int, description s
 // this case, if a template is returned, it may still be usable.)
 func (loader *TemplateLoader) Template(name string) (Template, error) {
 	// Case-insensitive matching of template file name
-	name = strings.ToLower(name)
-	for k := range loader.templatePaths {
-		if name == strings.ToLower(k) {
-			name = k
-		}
-	}
+	templateName := loader.templateNames[strings.ToLower(name)]
+
 	// Look up and return the template.
-	tmpl := loader.templateSet.Lookup(name)
+	tmpl := loader.templateSet.Lookup(templateName)
 
 	// This is necessary.
 	// If a nil loader.compileError is returned directly, a caller testing against


### PR DESCRIPTION
This PR addresses https://github.com/revel/revel/pull/753#commitcomment-9943539 and #729.

Behaviour of `Template` method from #753 should not be affected.
* If we have `index.html` and `Index.html` only one of them will be registered as template. And the second one will be ignored.
* If we have `{define "test"}` and `{define "TEST"}` the first declaration will be used and the second one ignored.
* Both `c.RenderTemplate("app/index.html")` and `c.RenderTemplate('App/Index.html')` work no matter what register `app` dir and `index.html` file have.

The only change is a map of lower case names is generated once. The map is then used to find a real name of template (whatever register it has). Thus, number of iterations to find the template we need (on average) will be decreased.