### PR TITLE
Makes validators work with UTF-8 strings

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"regexp"
 	"time"
+	"unicode/utf8"
 )
 
 type Validator interface {
@@ -24,7 +25,7 @@ func (r Required) IsSatisfied(obj interface{}) bool {
 	}
 
 	if str, ok := obj.(string); ok {
-		return len(str) > 0
+		return utf8.RuneCountInString(str) > 0
 	}
 	if b, ok := obj.(bool); ok {
 		return b
@@ -115,7 +116,7 @@ func ValidMinSize(min int) MinSize {
 
 func (m MinSize) IsSatisfied(obj interface{}) bool {
 	if str, ok := obj.(string); ok {
-		return len(str) >= m.Min
+		return utf8.RuneCountInString(str) >= m.Min
 	}
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Slice {
@@ -139,7 +140,7 @@ func ValidMaxSize(max int) MaxSize {
 
 func (m MaxSize) IsSatisfied(obj interface{}) bool {
 	if str, ok := obj.(string); ok {
-		return len(str) <= m.Max
+		return utf8.RuneCountInString(str) <= m.Max
 	}
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Slice {
@@ -163,7 +164,7 @@ func ValidLength(n int) Length {
 
 func (s Length) IsSatisfied(obj interface{}) bool {
 	if str, ok := obj.(string); ok {
-		return len(str) == s.N
+		return utf8.RuneCountInString(str) == s.N
 	}
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Slice {

--- a/validators_test.go
+++ b/validators_test.go
@@ -133,16 +133,17 @@ func TestRange(t *testing.T) {
 func TestMinSize(t *testing.T) {
 	greaterThanMessage := "len(val) >= min"
 	tests := []Expect{
-		Expect{"1", true, greaterThanMessage},
 		Expect{"12", true, greaterThanMessage},
-		Expect{[]int{1}, true, greaterThanMessage},
+		Expect{"123", true, greaterThanMessage},
 		Expect{[]int{1, 2}, true, greaterThanMessage},
+		Expect{[]int{1, 2, 3}, true, greaterThanMessage},
 		Expect{"", false, "len(val) <= min"},
+		Expect{"手", false, "len(val) <= min"},
 		Expect{[]int{}, false, "len(val) <= min"},
 		Expect{nil, false, "TypeOf(val) != string && TypeOf(val) != slice"},
 	}
 
-	for _, minSize := range []MinSize{MinSize{1}, ValidMinSize(1)} {
+	for _, minSize := range []MinSize{MinSize{2}, ValidMinSize(2)} {
 		performTests(minSize, tests, t)
 	}
 }
@@ -152,12 +153,14 @@ func TestMaxSize(t *testing.T) {
 	tests := []Expect{
 		Expect{"", true, lessThanMessage},
 		Expect{"12", true, lessThanMessage},
+		Expect{"ルビー", true, lessThanMessage},
 		Expect{[]int{}, true, lessThanMessage},
 		Expect{[]int{1, 2}, true, lessThanMessage},
-		Expect{"123", false, "len(val) >= max"},
-		Expect{[]int{1, 2, 3}, false, "len(val) >= max"},
+		Expect{[]int{1, 2, 3}, true, lessThanMessage},
+		Expect{"1234", false, "len(val) >= max"},
+		Expect{[]int{1, 2, 3, 4}, false, "len(val) >= max"},
 	}
-	for _, maxSize := range []MaxSize{MaxSize{2}, ValidMaxSize(2)} {
+	for _, maxSize := range []MaxSize{MaxSize{3}, ValidMaxSize(3)} {
 		performTests(maxSize, tests, t)
 	}
 }
@@ -165,6 +168,7 @@ func TestMaxSize(t *testing.T) {
 func TestLength(t *testing.T) {
 	tests := []Expect{
 		Expect{"12", true, "len(val) == length"},
+		Expect{"火箭", true, "len(val) == length"},
 		Expect{[]int{1, 2}, true, "len(val) == length"},
 		Expect{"123", false, "len(val) > length"},
 		Expect{[]int{1, 2, 3}, false, "len(val) > length"},


### PR DESCRIPTION
Removes `len`in favor of `utf8.RuneCountInString` when calculating length of strings in validators.

````go
len("ルビー")                       // 9 (wrong value)
utf8.RuneCountInString("ルビー")    // 3 (ok)
```