### PR TITLE
Fix broken fake app tests

### DIFF
--- a/fakeapp_test.go
+++ b/fakeapp_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"path/filepath"
 	"reflect"
 )
 
@@ -59,7 +58,7 @@ func (c Static) Serve(prefix, filepath string) Result {
 }
 
 func startFakeBookingApp() {
-	Init("prod", "github.com/revel/samples/booking", "")
+	Init("prod", "github.com/revel/revel/testdata", "")
 
 	// Disable logging.
 	TRACE = log.New(ioutil.Discard, "", 0)
@@ -67,12 +66,6 @@ func startFakeBookingApp() {
 	WARN = TRACE
 	ERROR = TRACE
 
-	runStartupHooks()
-
-	MainRouter = NewRouter("")
-	routesFile, _ := ioutil.ReadFile(filepath.Join(BasePath, "conf", "routes"))
-	MainRouter.Routes, _ = parseRoutes("", "", string(routesFile), false)
-	MainRouter.updateTree()
 	MainTemplateLoader = NewTemplateLoader([]string{ViewsPath, path.Join(RevelPath, "templates")})
 	MainTemplateLoader.Refresh()
 
@@ -86,7 +79,7 @@ func startFakeBookingApp() {
 				Args: []*MethodArg{
 					{"id", reflect.TypeOf((*int)(nil))},
 				},
-				RenderArgNames: map[int][]string{31: []string{"title", "hotel"}},
+				RenderArgNames: map[int][]string{30: []string{"title", "hotel"}},
 			},
 			&MethodType{
 				Name: "Book",
@@ -107,4 +100,6 @@ func startFakeBookingApp() {
 				RenderArgNames: map[int][]string{},
 			},
 		})
+
+	runStartupHooks()
 }

--- a/testdata/app/views/footer.html
+++ b/testdata/app/views/footer.html
@@ -1,0 +1,8 @@
+    </div>
+
+    <div id="footer">
+      Created with the <a href="http://github.com/revel/revel">Revel framework</a> and really inspirated from the booking sample application provided by <a href="http://www.playframework.org">play framework</a>, which was really inspired by the booking sample application provided by the <a href="http://seamframework.org/">seam framework</a>.
+    </div>
+
+  </body>
+</html>

--- a/testdata/app/views/header.html
+++ b/testdata/app/views/header.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>{{.title}}</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="stylesheet" type="text/css" media="screen" href="/public/css/main.css">
+    {{range .moreStyles}}
+      <link rel="stylesheet" type="text/css" href="/public/{{.}}">
+    {{end}}
+    <script src="/public/js/jquery-1.3.2.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="/public/js/sessvars.js" type="text/javascript" charset="utf-8"></script>
+    {{range .moreScripts}}
+      <script src="/public/{{.}}" type="text/javascript" charset="utf-8"></script>
+    {{end}}
+  </head>
+  <body>
+
+    <div id="header">
+      <h1>revel framework booking demo</h1>
+      {{if .user}}
+        <div id="options">
+          Connected as {{.user.Username}}
+          |
+          <a href="{{url "Hotels.Index"}}">Search</a>
+          |
+          <a href="{{url "Hotels.Settings"}}">Settings</a>
+          |
+          <a href="{{url "Application.Logout"}}">Logout</a>
+        </div>
+      {{end}}
+    </div>
+
+    <div id="content">
+      {{if .flash.error}}
+        <p class="fError">
+          <strong>{{.flash.error}}</strong>
+        </p>
+      {{end}}
+      {{if .flash.success}}
+        <p class="fSuccess">
+          <strong>{{.flash.success}}</strong>
+        </p>
+      {{end}}
+

--- a/testdata/app/views/hotels/show.html
+++ b/testdata/app/views/hotels/show.html
@@ -1,0 +1,37 @@
+{{template "header.html" .}}
+
+<h1>View hotel</h1>
+
+{{with .hotel}}
+<form action="{{url "Hotels.Book" .HotelId}}">
+
+  <p>
+    <strong>Name:</strong> {{.Name}}
+  </p>
+  <p>
+    <strong>Address:</strong> {{.Address}}
+  </p>
+  <p>
+    <strong>City:</strong> {{.City}}
+  </p>
+  <p>
+    <strong>State:</strong> {{.State}}
+  </p>
+  <p>
+    <strong>Zip:</strong> {{.Zip}}
+  </p>
+  <p>
+    <strong>Country:</strong> {{.Country}}
+  </p>
+  <p>
+    <strong>Nightly rate:</strong> {{.Price}}
+  </p>
+
+  <p class="buttons">
+    <input type="submit" value="Book Hotel">
+    <a href="{{url "Hotels.Index"}}">Back to search</a>
+  </p>
+</form>
+{{end}}
+
+{{template "footer.html" .}}

--- a/testdata/conf/app.conf
+++ b/testdata/conf/app.conf
@@ -1,0 +1,44 @@
+# Application
+app.name=Booking example
+app.secret=secret
+
+# Server
+http.addr=
+http.port=9000
+http.ssl=false
+http.sslcert=
+http.sslkey=
+
+# Logging
+log.trace.output = stderr
+log.info.output  = stderr
+log.warn.output  = stderr
+log.error.output = stderr
+
+log.trace.prefix = "TRACE "
+log.info.prefix  = "INFO  "
+log.warn.prefix  = "WARN  "
+log.error.prefix = "ERROR "
+
+db.import = github.com/mattn/go-sqlite3
+db.driver = sqlite3
+db.spec   = :memory:
+
+build.tags=gorp
+
+module.jobs=github.com/revel/modules/jobs
+module.static=github.com/revel/modules/static
+
+[dev]
+mode.dev=true
+watch=true
+module.testrunner=github.com/revel/modules/testrunner
+
+[prod]
+watch=false
+module.testrunner=
+
+log.trace.output = off
+log.info.output  = off
+log.warn.output  = stderr
+log.error.output = stderr

--- a/testdata/conf/routes
+++ b/testdata/conf/routes
@@ -1,0 +1,16 @@
+# Routes
+# This file defines all application routes (Higher priority routes first)
+# ~~~~
+
+module:testrunner
+
+GET     /hotels                                 Hotels.Index
+GET     /hotels/:id                             Hotels.Show
+GET     /hotels/:id/booking                     Hotels.Book
+
+# Map static resources from the /app/public folder to the /public path
+GET     /public/*filepath                       Static.Serve("public")
+GET     /favicon.ico                            Static.Serve("public/img","favicon.png")
+
+# Catch all
+*       /:controller/:action                    :controller.:action

--- a/testdata/public/js/sessvars.js
+++ b/testdata/public/js/sessvars.js
@@ -1,0 +1,1 @@
+console.log('Test file');


### PR DESCRIPTION
#855 revealed some problems with our fake app tests. Particularly, incorrect order of elements' initialization. This PR fixes broken tests.

There were two options: either to implement every of booking sample controllers + job module controller in out fake app. Or just move some booking sample's files to testdata directory and use them there. I have settle on the second option.

Now tests of revel/revel do not depend on revel/samples, only on revel/modules.

@brendensoares What else do we need for v0.12 release?