### PR TITLE
Use "302 Found" HTTP code for redirect

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -244,7 +244,7 @@ func (c *Controller) RenderBinary(memfile io.Reader, filename string, delivery C
 //   c.Redirect("/controller/action")
 //   c.Redirect("/controller/%d/action", id)
 func (c *Controller) Redirect(val interface{}, args ...interface{}) Result {
-	c.setStatusIfNil(http.StatusMovedPermanently)
+	c.setStatusIfNil(http.StatusFound)
 
 	if url, ok := val.(string); ok {
 		if len(args) == 0 {


### PR DESCRIPTION
#728 introduced "301 Permanent Redirect" for `Redirect` result. But the way we use `Redirect` method requires "302 Found" aka Moved Temporarily. This PR restores the status code we used before.