### PR TITLE
Output request starting and completed message in log like Rails:

### DIFF
--- a/revel.go
+++ b/revel.go
@@ -78,7 +78,7 @@ var (
 	//Logger colors
 	colors = map[string]gocolorize.Colorize{
 		"trace": gocolorize.NewColor("magenta"),
-		"info":  gocolorize.NewColor("green"),
+		"info":  gocolorize.NewColor("white"),
 		"warn":  gocolorize.NewColor("yellow"),
 		"error": gocolorize.NewColor("red"),
 	}
@@ -86,10 +86,11 @@ var (
 	error_log = revelLogs{c: colors["error"], w: os.Stderr}
 
 	// Loggers
-	TRACE = log.New(ioutil.Discard, "TRACE ", log.Ldate|log.Ltime|log.Lshortfile)
-	INFO  = log.New(ioutil.Discard, "INFO  ", log.Ldate|log.Ltime|log.Lshortfile)
-	WARN  = log.New(ioutil.Discard, "WARN  ", log.Ldate|log.Ltime|log.Lshortfile)
-	ERROR = log.New(&error_log, "ERROR ", log.Ldate|log.Ltime|log.Lshortfile)
+	TRACE   = log.New(ioutil.Discard, "  TRACE ", log.Ldate|log.Ltime|log.Lshortfile)
+	INFO    = log.New(ioutil.Discard, "  ", log.Ldate|log.Ltime|log.Lshortfile)
+	SYSINFO = log.New(ioutil.Discard, "", 0) // for Revel inner log
+	WARN    = log.New(ioutil.Discard, "  WARN ", log.Ldate|log.Ltime|log.Lshortfile)
+	ERROR   = log.New(&error_log, "  ERROR ", log.Ldate|log.Ltime|log.Lshortfile)
 
 	Initialized bool
 
@@ -197,6 +198,7 @@ func Init(mode, importPath, srcPath string) {
 
 	TRACE = getLogger("trace")
 	INFO = getLogger("info")
+	SYSINFO = getLogger("info")
 	WARN = getLogger("warn")
 	ERROR = getLogger("error")
 

--- a/revel.go
+++ b/revel.go
@@ -77,17 +77,18 @@ var (
 
 	//Logger colors
 	colors = map[string]gocolorize.Colorize{
-		"trace": gocolorize.NewColor("magenta"),
-		"info":  gocolorize.NewColor("white"),
-		"warn":  gocolorize.NewColor("yellow"),
-		"error": gocolorize.NewColor("red"),
+		"trace":   gocolorize.NewColor("magenta"),
+		"info":    gocolorize.NewColor("white"),
+		"sysinfo": gocolorize.NewColor("white"),
+		"warn":    gocolorize.NewColor("yellow"),
+		"error":   gocolorize.NewColor("red"),
 	}
 
 	error_log = revelLogs{c: colors["error"], w: os.Stderr}
 
 	// Loggers
 	TRACE   = log.New(ioutil.Discard, "  TRACE ", log.Ldate|log.Ltime|log.Lshortfile)
-	INFO    = log.New(ioutil.Discard, "  ", log.Ldate|log.Ltime|log.Lshortfile)
+	INFO    = log.New(ioutil.Discard, "  ", 0)
 	SYSINFO = log.New(ioutil.Discard, "", 0) // for Revel inner log
 	WARN    = log.New(ioutil.Discard, "  WARN ", log.Ldate|log.Ltime|log.Lshortfile)
 	ERROR   = log.New(&error_log, "  ERROR ", log.Ldate|log.Ltime|log.Lshortfile)
@@ -198,14 +199,14 @@ func Init(mode, importPath, srcPath string) {
 
 	TRACE = getLogger("trace")
 	INFO = getLogger("info")
-	SYSINFO = getLogger("info")
+	SYSINFO = getLogger("sysinfo")
 	WARN = getLogger("warn")
 	ERROR = getLogger("error")
 
 	loadModules()
 
 	Initialized = true
-	INFO.Printf("Initialized Revel v%s (%s) for %s", VERSION, BUILD_DATE, MINIMUM_GO)
+	SYSINFO.Printf("Initialized Revel v%s (%s) for %s", VERSION, BUILD_DATE, MINIMUM_GO)
 }
 
 // Create a logger using log.* directives in app.conf plus the current settings
@@ -328,7 +329,7 @@ func addModule(name, importPath, modulePath string) {
 		}
 	}
 
-	INFO.Print("Loaded module ", path.Base(modulePath))
+	SYSINFO.Print("Loaded module ", path.Base(modulePath))
 
 	// Hack: There is presently no way for the testrunner module to add the
 	// "test" subdirectory to the CodePaths.  So this does it instead.

--- a/server.go
+++ b/server.go
@@ -22,7 +22,6 @@ var (
 // This method handles all requests.  It dispatches to handleInternal after
 // handling / adapting websocket connections.
 func handle(w http.ResponseWriter, r *http.Request) {
-
 	if maxRequestSize := int64(Config.IntDefault("http.maxrequestsize", 0)); maxRequestSize > 0 {
 		r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 	}
@@ -42,7 +41,8 @@ func handle(w http.ResponseWriter, r *http.Request) {
 
 func handleInternal(w http.ResponseWriter, r *http.Request, ws *websocket.Conn) {
 	t1 := time.Now()
-	INFO.Println("\nStarted", r.Method, r.URL.String(), "at", time.Now().Format(time.RFC3339), "from", r.RemoteAddr)
+	SYSINFO.SetPrefix("")
+	SYSINFO.Println("\nStarted", r.Method, r.URL.String(), "at", time.Now().Format(time.RFC3339), "from", r.RemoteAddr)
 
 	var (
 		req  = NewRequest(r)
@@ -63,7 +63,7 @@ func handleInternal(w http.ResponseWriter, r *http.Request, ws *websocket.Conn) 
 	}
 
 	duration := fmt.Sprintf("%.2fms", float64(time.Since(t1).Nanoseconds()/1e4)/100.0)
-	INFO.Println("\nComplated", c.Response.Status, "in", duration, "\n")
+	SYSINFO.Println("Complated", c.Response.Status, "in", duration, "\n")
 }
 
 // Run the server.

--- a/server.go
+++ b/server.go
@@ -22,6 +22,7 @@ var (
 // This method handles all requests.  It dispatches to handleInternal after
 // handling / adapting websocket connections.
 func handle(w http.ResponseWriter, r *http.Request) {
+
 	if maxRequestSize := int64(Config.IntDefault("http.maxrequestsize", 0)); maxRequestSize > 0 {
 		r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 	}
@@ -40,6 +41,9 @@ func handle(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleInternal(w http.ResponseWriter, r *http.Request, ws *websocket.Conn) {
+	t1 := time.Now()
+	INFO.Println("\nStarted", r.Method, r.URL.String(), "at", time.Now().Format(time.RFC3339), "from", r.RemoteAddr)
+
 	var (
 		req  = NewRequest(r)
 		resp = NewResponse(w)
@@ -57,6 +61,9 @@ func handleInternal(w http.ResponseWriter, r *http.Request, ws *websocket.Conn) 
 	if w, ok := resp.Out.(io.Closer); ok {
 		w.Close()
 	}
+
+	duration := fmt.Sprintf("%.2fms", float64(time.Since(t1).Nanoseconds()/1e4)/100.0)
+	INFO.Println("\nComplated", c.Response.Status, "in", duration, "\n")
 }
 
 // Run the server.

--- a/session.go
+++ b/session.go
@@ -121,7 +121,7 @@ func GetSessionFromCookie(cookie *http.Cookie) Session {
 
 	// Verify the signature.
 	if !Verify(data, sig) {
-		INFO.Println("Session cookie signature failed")
+		WARN.Println("Session cookie signature failed")
 		return session
 	}
 

--- a/skeleton/conf/app.conf.template
+++ b/skeleton/conf/app.conf.template
@@ -79,10 +79,10 @@ results.chunked = false
 
 
 # Prefixes for each log message line
-log.trace.prefix = "TRACE "
-log.info.prefix  = "INFO  "
-log.warn.prefix  = "WARN  "
-log.error.prefix = "ERROR "
+log.trace.prefix = "  TRACE "
+log.info.prefix  = "  "
+log.warn.prefix  = "  WARN "
+log.error.prefix = "  ERROR "
 
 
 # The default language of this application.


### PR DESCRIPTION
```bash
Started GET /topics at 2015-03-28T18:09:41+08:00 from 127.0.0.1:57816
  [app.go:54] (0.72ms) SELECT  * FROM `users`  WHERE (`users`.deleted_at IS NULL OR `users`.deleted_at <= '0001-01-02') AND ((id = '13')) ORDER BY `users`.id ASC LIMIT 1
  [pagination.go:19] (0.59ms) SELECT  count(*) FROM `topics`  WHERE (`topics`.deleted_at IS NULL OR `topics`.deleted_at <= '0001-01-02') AND ((rank >= 0)) ORDER BY last_active_mark desc, id desc
  [topic.go:83] (1.97ms) SELECT  * FROM `topics`  WHERE (`topics`.deleted_at IS NULL OR `topics`.deleted_at <= '0001-01-02') AND ((rank >= 0)) ORDER BY last_active_mark desc, id desc LIMIT 20 OFFSET 0
  [topic.go:83] (0.82ms) SELECT  * FROM `users`  WHERE (`users`.deleted_at IS NULL OR `users`.deleted_at <= '0001-01-02') AND ((`id` in ('8','13','14')))
  [topic.go:83] (0.74ms) SELECT  * FROM `nodes`  WHERE (`nodes`.deleted_at IS NULL OR `nodes`.deleted_at <= '0001-01-02') AND ((`id` in ('2','0','9','12','10','11','15','1')))
  [ERROR]0 RenderArg names found for 1 extra RenderArgs
  [user.go:61] (0.57ms) SELECT  count(*) FROM `notifications`  WHERE (`user_id` = '13' and `read` = 0)
  [user.go:61] (0.60ms) SELECT  count(*) FROM `notifications`  WHERE (`user_id` = '13' and `read` = 0)
  [node.go:62] (0.58ms) SELECT  * FROM `node_groups`   ORDER BY sort desc
  [node.go:62] (1.34ms) SELECT  * FROM `nodes`  WHERE (`nodes`.deleted_at IS NULL OR `nodes`.deleted_at <= '0001-01-02') AND ((`node_group_id` IN ('1','2')))
Complated 200 in 18.32ms
```

## Changes:

1. Add instrument log for each request.
2. INFO logger use white color.
3. Update default log prefix for output tidy log.
4. Add SYSINFO logger.

## Example:

![2015-03-28 18 16 01](https://cloud.githubusercontent.com/assets/5518/6880617/89051750-d576-11e4-9749-6c7fe4bac35a.png)
