### PR TITLE
Fix function not working on Windows because of backslash

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -107,6 +107,7 @@ func (e *Error) ContextSource() []sourceLine {
 // Return the character index of the first relevant stack frame, or -1 if none were found.
 // Additionally it returns the base path of the tree in which the identified code resides.
 func findRelevantStackFrame(stack string) (int, string) {
+	BasePath = strings.Replace(BasePath, "\\", "/", -1)
 	if frame := strings.Index(stack, BasePath); frame != -1 {
 		return frame, BasePath
 	}


### PR DESCRIPTION
So it turns out us Windows folk have been missing out on very nice detailed information in the testrunner module. All we would get is a red bar with no information when a test failed....we thought this was normal until a Linux user pointed out the fact that he had all of this information on why a test failed inline.

This fixes the issue, problem is the base path on Windows looks like `C:\Gopath\src/github.com/blabla/blabla`. Converting all of the backslashes to forward slashes fixes this fully :).