### PR TITLE
always use HttpOnly and default to Secure cookies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - redis-server
 install:
   - export PATH=$PATH:$HOME/gopath/bin
-  - export REVEL_BRANCH="master"
+  - export REVEL_BRANCH="develop"
   - 'if [[ "$TRAVIS_BRANCH" == "master" ]]; then export REVEL_BRANCH="master"; fi'
   - 'echo "Travis branch: $TRAVIS_BRANCH, Revel dependency branch: $REVEL_BRANCH"'
   - go get -v github.com/revel/revel/...

--- a/flash.go
+++ b/flash.go
@@ -53,7 +53,7 @@ func FlashFilter(c *Controller, fc []Filter) {
 	c.SetCookie(&http.Cookie{
 		Name:     CookiePrefix + "_FLASH",
 		Value:    url.QueryEscape(flashValue),
-		HttpOnly: CookieHttpOnly,
+		HttpOnly: true,
 		Secure:   CookieSecure,
 		Path:     "/",
 	})

--- a/revel.go
+++ b/revel.go
@@ -1,8 +1,6 @@
 package revel
 
 import (
-	"github.com/agtorre/gocolorize"
-	"github.com/robfig/config"
 	"go/build"
 	"io"
 	"io/ioutil"
@@ -12,6 +10,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/agtorre/gocolorize"
+	"github.com/robfig/config"
 )
 
 const (
@@ -69,8 +70,7 @@ var (
 	// Cookie domain
 	CookieDomain string
 	// Cookie flags
-	CookieHttpOnly bool
-	CookieSecure   bool
+	CookieSecure bool
 
 	// Delimiters to use when rendering templates
 	TemplateDelims string
@@ -183,8 +183,7 @@ func Init(mode, importPath, srcPath string) {
 	AppRoot = Config.StringDefault("app.root", "")
 	CookiePrefix = Config.StringDefault("cookie.prefix", "REVEL")
 	CookieDomain = Config.StringDefault("cookie.domain", "")
-	CookieHttpOnly = Config.BoolDefault("cookie.httponly", false)
-	CookieSecure = Config.BoolDefault("cookie.secure", false)
+	CookieSecure = Config.BoolDefault("cookie.secure", !DevMode)
 	TemplateDelims = Config.StringDefault("template.delimiters", "")
 	if secretStr := Config.StringDefault("app.secret", ""); secretStr != "" {
 		secretKey = []byte(secretStr)

--- a/server.go
+++ b/server.go
@@ -85,8 +85,8 @@ func Run(port int) {
 	Server = &http.Server{
 		Addr:         localAddress,
 		Handler:      http.HandlerFunc(handle),
-		ReadTimeout:  time.Minute,
-		WriteTimeout: time.Minute,
+		ReadTimeout:  time.Duration(Config.IntDefault("timeout.read", 0)) * time.Second,
+		WriteTimeout: time.Duration(Config.IntDefault("timeout.write", 0)) * time.Second,
 	}
 
 	runStartupHooks()

--- a/session.go
+++ b/session.go
@@ -87,7 +87,7 @@ func (s Session) Cookie() *http.Cookie {
 		Value:    Sign(sessionData) + "-" + sessionData,
 		Domain:   CookieDomain,
 		Path:     "/",
-		HttpOnly: CookieHttpOnly,
+		HttpOnly: true,
 		Secure:   CookieSecure,
 		Expires:  ts.UTC(),
 	}

--- a/skeleton/conf/app.conf.template
+++ b/skeleton/conf/app.conf.template
@@ -36,14 +36,6 @@ http.ssl = false
 # the fields of:
 # http://golang.org/pkg/net/http/#Cookie
 #
-# The HttpOnly attribute is supported by most modern browsers. On a supported
-# browser, an HttpOnly session cookie will be used only when transmitting HTTP
-# (or HTTPS) requests, thus restricting access from other, non-HTTP APIs (such
-# as JavaScript). This restriction mitigates, but does not eliminate the threat
-# of session cookie theft via cross-site scripting (XSS). This feature applies
-# only to session-management cookies, and not other browser cookies.
-cookie.httponly = false
-
 # Each cookie set by Revel is prefixed with this string.
 cookie.prefix = REVEL
 
@@ -51,7 +43,10 @@ cookie.prefix = REVEL
 # ensuring that the cookie is always encrypted when transmitting from client to
 # server. This makes the cookie less likely to be exposed to cookie theft via
 # eavesdropping.
-cookie.secure = false
+#
+# In dev mode, this will be default to false. In not dev mode, it will
+# be defaulted to on.
+# cookie.secure = false
 
 # Limit cookie access to a given domain
 #cookie.domain =

--- a/testing/testsuite.go
+++ b/testing/testsuite.go
@@ -133,6 +133,18 @@ func (t *TestSuite) PutCustom(uri string, contentType string, reader io.Reader) 
 	return t.NewTestRequest(req)
 }
 
+// Issue a PUT request to the given path as a form put of the given key and
+// values, and store the result in Response and ResponseBody.
+func (t *TestSuite) PutForm(path string, data url.Values) {
+    t.PutFormCustom(t.BaseUrl()+path, data).Send()
+}
+
+// Return a PUT request to the given uri as a form put of the given key and values.
+// The request is in a form of TestRequest wrapper.
+func (t *TestSuite) PutFormCustom(uri string, data url.Values) *TestRequest {
+    return t.PutCustom(uri, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}
+
 // Issue a PATCH request to the given path, sending the given Content-Type and
 // data, and store the result in Response and ResponseBody.  "data" may be nil.
 func (t *TestSuite) Patch(path string, contentType string, reader io.Reader) {

--- a/validation.go
+++ b/validation.go
@@ -212,7 +212,7 @@ func ValidationFilter(c *Controller, fc []Filter) {
 			Value:    url.QueryEscape(errorsValue),
 			Domain:   CookieDomain,
 			Path:     "/",
-			HttpOnly: CookieHttpOnly,
+			HttpOnly: true,
 			Secure:   CookieSecure,
 		})
 	} else if hasCookie {
@@ -221,7 +221,7 @@ func ValidationFilter(c *Controller, fc []Filter) {
 			MaxAge:   -1,
 			Domain:   CookieDomain,
 			Path:     "/",
-			HttpOnly: CookieHttpOnly,
+			HttpOnly: true,
 			Secure:   CookieSecure,
 		})
 	}

--- a/validators.go
+++ b/validators.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"regexp"
 	"time"
+	"unicode/utf8"
 )
 
 type Validator interface {
@@ -24,7 +25,7 @@ func (r Required) IsSatisfied(obj interface{}) bool {
 	}
 
 	if str, ok := obj.(string); ok {
-		return len(str) > 0
+		return utf8.RuneCountInString(str) > 0
 	}
 	if b, ok := obj.(bool); ok {
 		return b
@@ -115,7 +116,7 @@ func ValidMinSize(min int) MinSize {
 
 func (m MinSize) IsSatisfied(obj interface{}) bool {
 	if str, ok := obj.(string); ok {
-		return len(str) >= m.Min
+		return utf8.RuneCountInString(str) >= m.Min
 	}
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Slice {
@@ -139,7 +140,7 @@ func ValidMaxSize(max int) MaxSize {
 
 func (m MaxSize) IsSatisfied(obj interface{}) bool {
 	if str, ok := obj.(string); ok {
-		return len(str) <= m.Max
+		return utf8.RuneCountInString(str) <= m.Max
 	}
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Slice {
@@ -163,7 +164,7 @@ func ValidLength(n int) Length {
 
 func (s Length) IsSatisfied(obj interface{}) bool {
 	if str, ok := obj.(string); ok {
-		return len(str) == s.N
+		return utf8.RuneCountInString(str) == s.N
 	}
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Slice {

--- a/validators_test.go
+++ b/validators_test.go
@@ -133,16 +133,17 @@ func TestRange(t *testing.T) {
 func TestMinSize(t *testing.T) {
 	greaterThanMessage := "len(val) >= min"
 	tests := []Expect{
-		Expect{"1", true, greaterThanMessage},
 		Expect{"12", true, greaterThanMessage},
-		Expect{[]int{1}, true, greaterThanMessage},
+		Expect{"123", true, greaterThanMessage},
 		Expect{[]int{1, 2}, true, greaterThanMessage},
+		Expect{[]int{1, 2, 3}, true, greaterThanMessage},
 		Expect{"", false, "len(val) <= min"},
+		Expect{"手", false, "len(val) <= min"},
 		Expect{[]int{}, false, "len(val) <= min"},
 		Expect{nil, false, "TypeOf(val) != string && TypeOf(val) != slice"},
 	}
 
-	for _, minSize := range []MinSize{MinSize{1}, ValidMinSize(1)} {
+	for _, minSize := range []MinSize{MinSize{2}, ValidMinSize(2)} {
 		performTests(minSize, tests, t)
 	}
 }
@@ -152,12 +153,14 @@ func TestMaxSize(t *testing.T) {
 	tests := []Expect{
 		Expect{"", true, lessThanMessage},
 		Expect{"12", true, lessThanMessage},
+		Expect{"ルビー", true, lessThanMessage},
 		Expect{[]int{}, true, lessThanMessage},
 		Expect{[]int{1, 2}, true, lessThanMessage},
-		Expect{"123", false, "len(val) >= max"},
-		Expect{[]int{1, 2, 3}, false, "len(val) >= max"},
+		Expect{[]int{1, 2, 3}, true, lessThanMessage},
+		Expect{"1234", false, "len(val) >= max"},
+		Expect{[]int{1, 2, 3, 4}, false, "len(val) >= max"},
 	}
-	for _, maxSize := range []MaxSize{MaxSize{2}, ValidMaxSize(2)} {
+	for _, maxSize := range []MaxSize{MaxSize{3}, ValidMaxSize(3)} {
 		performTests(maxSize, tests, t)
 	}
 }
@@ -165,6 +168,7 @@ func TestMaxSize(t *testing.T) {
 func TestLength(t *testing.T) {
 	tests := []Expect{
 		Expect{"12", true, "len(val) == length"},
+		Expect{"火箭", true, "len(val) == length"},
 		Expect{[]int{1, 2}, true, "len(val) == length"},
 		Expect{"123", false, "len(val) > length"},
 		Expect{[]int{1, 2, 3}, false, "len(val) > length"},


### PR DESCRIPTION
Always use Secure cookies (that is, require HTTPS for the cookie to be
used) unless we're in dev mode.

Always set the session cookies as HttpOnly so that XSS attacks can't dig
into them. They'll still be set on XHR requests, but the JavaScript
code won't see it.

Closes #942