### PR TITLE
Renamed watcher config to watch to be consistent

### DIFF
--- a/skeleton/conf/app.conf.template
+++ b/skeleton/conf/app.conf.template
@@ -115,9 +115,9 @@ results.pretty = true
 watch = true
 
 
-# If you set watcher.mode = "eager", the server starts to recompile
+# If you set watch.mode = "eager", the server starts to recompile
 # your application every time your application's files change.
-watcher.mode = "normal"
+watch.mode = "normal"
 
 
 # Module to run code tests in the browser

--- a/watcher.go
+++ b/watcher.go
@@ -198,13 +198,13 @@ func (w *Watcher) Notify() *Error {
 	return nil
 }
 
-// If watcher.mode is set to eager, the application is rebuilt immediately
+// If watch.mode is set to eager, the application is rebuilt immediately
 // when a source file is changed.
 // This feature is available only in dev mode.
 func (w *Watcher) eagerRebuildEnabled() bool {
 	return Config.BoolDefault("mode.dev", true) &&
 		Config.BoolDefault("watch", true) &&
-		Config.StringDefault("watcher.mode", "normal") == "eager"
+		Config.StringDefault("watch.mode", "normal") == "eager"
 }
 
 func (w *Watcher) rebuildRequired(ev fsnotify.Event, listener Listener) bool {


### PR DESCRIPTION
@revel/core 