### PR TITLE
Use improved deflate/gzip compressor.

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -1,12 +1,13 @@
 package revel
 
 import (
-	"compress/gzip"
-	"compress/zlib"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/zlib"
 )
 
 var compressionTypes = [...]string{


### PR DESCRIPTION
This pure-Go library (by yours truly) has optimized gzip/deflate function. At default compression levels this gives ~70% improvement in throughput for web content, as well as fewer allocations.

For performance comparisons see the package and https://blog.klauspost.com/gzip-performance-for-go-webservers/

I would love to give revel-specific benchmarks, but the benchmarks in "compress_test.go" appear broken, since it doesn't seem like compression is applied at all.