### PR TITLE
add Pluggable template engine support

### DIFF
--- a/fakeapp_test.go
+++ b/fakeapp_test.go
@@ -67,7 +67,9 @@ func startFakeBookingApp() {
 	ERROR = TRACE
 
 	MainTemplateLoader = NewTemplateLoader([]string{ViewsPath, path.Join(RevelPath, "templates")})
-	MainTemplateLoader.Refresh()
+	if err := MainTemplateLoader.Refresh(); nil != err {
+		panic(err)
+	}
 
 	RegisterController((*Hotels)(nil),
 		[]*MethodType{

--- a/revel.go
+++ b/revel.go
@@ -201,7 +201,7 @@ func Init(mode, importPath, srcPath string) {
 	WARN = getLogger("warn")
 	ERROR = getLogger("error")
 
-	if GO_TEMPLATE == Config.StringDefault(REVEL_TEMPLATE_ENGINE, GO_TEMPLATE) {
+	if tmpl := Config.StringDefault(REVEL_TEMPLATE_ENGINE, GO_TEMPLATE); GO_TEMPLATE == tmpl || MIXED_TEMPLATE == tmpl {
 		TemplatePaths = append(TemplatePaths, path.Join(RevelPath, "templates"))
 	}
 

--- a/revel.go
+++ b/revel.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	REVEL_IMPORT_PATH = "github.com/revel/revel"
+	REVEL_TEMPLATE_ENGINE = "template.engine"
+	REVEL_IMPORT_PATH     = "github.com/revel/revel"
 )
 
 type revelLogs struct {
@@ -73,9 +74,6 @@ var (
 	CookieDomain string
 	// Cookie flags
 	CookieSecure bool
-
-	// Delimiters to use when rendering templates
-	TemplateDelims string
 
 	//Logger colors
 	colors = map[string]gocolorize.Colorize{
@@ -150,7 +148,6 @@ func Init(mode, importPath, srcPath string) {
 
 	TemplatePaths = []string{
 		ViewsPath,
-		path.Join(RevelPath, "templates"),
 	}
 
 	// Load app.conf
@@ -190,7 +187,6 @@ func Init(mode, importPath, srcPath string) {
 	CookiePrefix = Config.StringDefault("cookie.prefix", "REVEL")
 	CookieDomain = Config.StringDefault("cookie.domain", "")
 	CookieSecure = Config.BoolDefault("cookie.secure", !DevMode)
-	TemplateDelims = Config.StringDefault("template.delimiters", "")
 	if secretStr := Config.StringDefault("app.secret", ""); secretStr != "" {
 		secretKey = []byte(secretStr)
 	}
@@ -204,6 +200,10 @@ func Init(mode, importPath, srcPath string) {
 	INFO = getLogger("info")
 	WARN = getLogger("warn")
 	ERROR = getLogger("error")
+
+	if GO_TEMPLATE == Config.StringDefault(REVEL_TEMPLATE_ENGINE, GO_TEMPLATE) {
+		TemplatePaths = append(TemplatePaths, path.Join(RevelPath, "templates"))
+	}
 
 	loadModules()
 

--- a/server.go
+++ b/server.go
@@ -110,7 +110,7 @@ func Run(port int) {
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		fmt.Printf("Listening on %s...\n", localAddress)
+		fmt.Printf("Listening on %s...\n", Server.Addr)
 	}()
 
 	if HttpSsl {
@@ -122,7 +122,7 @@ func Run(port int) {
 		ERROR.Fatalln("Failed to listen:",
 			Server.ListenAndServeTLS(HttpSslCert, HttpSslKey))
 	} else {
-		listener, err := net.Listen(network, localAddress)
+		listener, err := net.Listen(network, Server.Addr)
 		if err != nil {
 			ERROR.Fatalln("Failed to listen:", err)
 		}

--- a/template.go
+++ b/template.go
@@ -16,6 +16,8 @@ import (
 const MIXED_TEMPLATE = "mixed"
 const GO_TEMPLATE = "go"
 
+var default_template_engine_name = GO_TEMPLATE
+
 var ERROR_CLASS = "hasError"
 
 // This object handles loading and parsing of templates.
@@ -71,7 +73,7 @@ func NewTemplateLoader(paths []string) *TemplateLoader {
 // Sets the template API methods for parsing and storing templates before rendering
 func (loader *TemplateLoader) CreateTemplateEngine(templateEngineName string) (TemplateEngine, error) {
 	if "" == templateEngineName {
-		templateEngineName = GO_TEMPLATE
+		templateEngineName = default_template_engine_name
 	}
 	factory := TemplateEngines[templateEngineName]
 	if nil == factory {
@@ -97,6 +99,12 @@ func (loader *TemplateLoader) Refresh() *Error {
 
 	// Walk through the template loader's paths and build up a template set.
 	templateEngineName, _ := Config.String(REVEL_TEMPLATE_ENGINE)
+	if MIXED_TEMPLATE == templateEngineName {
+		default_template_engine_name, _ = Config.String("template.default_engine")
+		if "" == default_template_engine_name {
+			default_template_engine_name = GO_TEMPLATE
+		}
+	}
 	var templatesAndEngine, err = loader.CreateTemplateEngine(templateEngineName)
 	if nil != err {
 		loader.compileError = &Error{

--- a/template.go
+++ b/template.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 )
 
+const MIXED_TEMPLATE = "mixed"
 const GO_TEMPLATE = "go"
 
 var ERROR_CLASS = "hasError"
@@ -68,8 +69,7 @@ func NewTemplateLoader(paths []string) *TemplateLoader {
 
 // Sets the template name from Config
 // Sets the template API methods for parsing and storing templates before rendering
-func (loader *TemplateLoader) createTemplateEngine() (TemplateEngine, error) {
-	templateEngineName, _ := Config.String(REVEL_TEMPLATE_ENGINE)
+func (loader *TemplateLoader) CreateTemplateEngine(templateEngineName string) (TemplateEngine, error) {
 	if "" == templateEngineName {
 		templateEngineName = GO_TEMPLATE
 	}
@@ -96,7 +96,8 @@ func (loader *TemplateLoader) Refresh() *Error {
 	loader.TemplatePaths = map[string]string{}
 
 	// Walk through the template loader's paths and build up a template set.
-	var templatesAndEngine, err = loader.createTemplateEngine()
+	templateEngineName, _ := Config.String(REVEL_TEMPLATE_ENGINE)
+	var templatesAndEngine, err = loader.CreateTemplateEngine(templateEngineName)
 	if nil != err {
 		loader.compileError = &Error{
 			Title:       "Panic (Template Loader)",

--- a/template_adapter_go.go
+++ b/template_adapter_go.go
@@ -1,0 +1,229 @@
+package revel
+
+import (
+	"fmt"
+	"html"
+	"html/template"
+	"io"
+	"log"
+	"reflect"
+	"strings"
+	"time"
+)
+
+var (
+	// The functions available for use in the templates.
+	TemplateFuncs = map[string]interface{}{
+		"url": ReverseUrl,
+		"set": func(renderArgs map[string]interface{}, key string, value interface{}) template.JS {
+			renderArgs[key] = value
+			return template.JS("")
+		},
+		"append": func(renderArgs map[string]interface{}, key string, value interface{}) template.JS {
+			if renderArgs[key] == nil {
+				renderArgs[key] = []interface{}{value}
+			} else {
+				renderArgs[key] = append(renderArgs[key].([]interface{}), value)
+			}
+			return template.JS("")
+		},
+		"field": NewField,
+		"firstof": func(args ...interface{}) interface{} {
+			for _, val := range args {
+				switch val.(type) {
+				case nil:
+					continue
+				case string:
+					if val == "" {
+						continue
+					}
+					return val
+				default:
+					return val
+				}
+			}
+			return nil
+		},
+		"option": func(f *Field, val interface{}, label string) template.HTML {
+			selected := ""
+			if f.Flash() == val || (f.Flash() == "" && f.Value() == val) {
+				selected = " selected"
+			}
+
+			return template.HTML(fmt.Sprintf(`<option value="%s"%s>%s</option>`,
+				html.EscapeString(fmt.Sprintf("%v", val)), selected, html.EscapeString(label)))
+		},
+		"radio": func(f *Field, val string) template.HTML {
+			checked := ""
+			if f.Flash() == val {
+				checked = " checked"
+			}
+			return template.HTML(fmt.Sprintf(`<input type="radio" name="%s" value="%s"%s>`,
+				html.EscapeString(f.Name), html.EscapeString(val), checked))
+		},
+		"checkbox": func(f *Field, val string) template.HTML {
+			checked := ""
+			if f.Flash() == val {
+				checked = " checked"
+			}
+			return template.HTML(fmt.Sprintf(`<input type="checkbox" name="%s" value="%s"%s>`,
+				html.EscapeString(f.Name), html.EscapeString(val), checked))
+		},
+		// Pads the given string with &nbsp;'s up to the given width.
+		"pad": func(str string, width int) template.HTML {
+			if len(str) >= width {
+				return template.HTML(html.EscapeString(str))
+			}
+			return template.HTML(html.EscapeString(str) + strings.Repeat("&nbsp;", width-len(str)))
+		},
+
+		"errorClass": func(name string, renderArgs map[string]interface{}) template.HTML {
+			errorMap, ok := renderArgs["errors"].(map[string]*ValidationError)
+			if !ok || errorMap == nil {
+				WARN.Println("Called 'errorClass' without 'errors' in the render args.")
+				return template.HTML("")
+			}
+			valError, ok := errorMap[name]
+			if !ok || valError == nil {
+				return template.HTML("")
+			}
+			return template.HTML(ERROR_CLASS)
+		},
+
+		"msg": func(renderArgs map[string]interface{}, message string, args ...interface{}) template.HTML {
+			str, ok := renderArgs[CurrentLocaleRenderArg].(string)
+			if !ok {
+				return ""
+			}
+			return template.HTML(MessageFunc(str, message, args...))
+		},
+
+		// Replaces newlines with <br>
+		"nl2br": func(text string) template.HTML {
+			return template.HTML(strings.Replace(template.HTMLEscapeString(text), "\n", "<br>", -1))
+		},
+
+		// Skips sanitation on the parameter.  Do not use with dynamic data.
+		"raw": func(text string) template.HTML {
+			return template.HTML(text)
+		},
+
+		// Pluralize, a helper for pluralizing words to correspond to data of dynamic length.
+		// items - a slice of items, or an integer indicating how many items there are.
+		// pluralOverrides - optional arguments specifying the output in the
+		//     singular and plural cases.  by default "" and "s"
+		"pluralize": func(items interface{}, pluralOverrides ...string) string {
+			singular, plural := "", "s"
+			if len(pluralOverrides) >= 1 {
+				singular = pluralOverrides[0]
+				if len(pluralOverrides) == 2 {
+					plural = pluralOverrides[1]
+				}
+			}
+
+			switch v := reflect.ValueOf(items); v.Kind() {
+			case reflect.Int:
+				if items.(int) != 1 {
+					return plural
+				}
+			case reflect.Slice:
+				if v.Len() != 1 {
+					return plural
+				}
+			default:
+				ERROR.Println("pluralize: unexpected type: ", v)
+			}
+			return singular
+		},
+
+		// Format a date according to the application's default date(time) format.
+		"date": func(date time.Time) string {
+			return date.Format(DateFormat)
+		},
+		"datetime": func(date time.Time) string {
+			return date.Format(DateTimeFormat)
+		},
+		"slug": Slug,
+		"even": func(a int) bool { return (a % 2) == 0 },
+	}
+)
+
+// Adapter for Go Templates.
+type GoTemplate struct {
+	*template.Template
+	engine *GoEngine
+}
+
+// return a 'revel.Template' from Go's template.
+func (gotmpl GoTemplate) Render(wr io.Writer, arg interface{}) error {
+	return gotmpl.Execute(wr, arg)
+}
+
+func (gotmpl GoTemplate) Content() []string {
+	content, _ := ReadLines(gotmpl.engine.loader.TemplatePaths[gotmpl.Name()])
+	return content
+}
+
+type GoEngine struct {
+	loader      *TemplateLoader
+	templateSet *template.Template
+	// TemplatesBylowerName is a map from lower case template name to the real template.
+	templatesBylowerName map[string]*template.Template
+	splitDelims          []string
+}
+
+func (engine *GoEngine) ParseAndAdd(templateName string, templateSource string, basePath string) *Error {
+	// If alternate delimiters set for the project, change them for this set
+	if engine.splitDelims != nil && basePath == ViewsPath {
+		engine.templateSet.Delims(engine.splitDelims[0], engine.splitDelims[1])
+	} else {
+		// Reset to default otherwise
+		engine.templateSet.Delims("", "")
+	}
+
+	tmpl, err := engine.templateSet.New(templateName).Parse(templateSource)
+	if nil != err {
+		_, line, description := parseTemplateError(err)
+		return &Error{
+			Title:       "Template Compilation Error",
+			Path:        templateName,
+			Description: description,
+			Line:        line,
+			SourceLines: strings.Split(templateSource, "\n"),
+		}
+	}
+	engine.templatesBylowerName[strings.ToLower(templateName)] = tmpl
+	return nil
+}
+
+func (engine *GoEngine) Lookup(templateName string) Template {
+	// Case-insensitive matching of template file name
+	tpl := engine.templatesBylowerName[strings.ToLower(templateName)]
+	if nil == tpl {
+		return nil
+	}
+	return GoTemplate{tpl, engine}
+}
+
+func init() {
+	TemplateEngines[GO_TEMPLATE] = func(loader *TemplateLoader) (TemplateEngine, error) {
+		// Set the template delimiters for the project if present, then split into left
+		// and right delimiters around a space character
+
+		TemplateDelims := Config.StringDefault("template.go.delimiters", "")
+		var splitDelims []string
+		if TemplateDelims != "" {
+			splitDelims = strings.Split(TemplateDelims, " ")
+			if len(splitDelims) != 2 {
+				log.Fatalln("app.conf: Incorrect format for template.delimiters")
+			}
+		}
+
+		return &GoEngine{
+			loader:               loader,
+			templateSet:          template.New("__root__").Funcs(TemplateFuncs),
+			templatesBylowerName: map[string]*template.Template{},
+			splitDelims:          splitDelims,
+		}, nil
+	}
+}

--- a/template_adapter_mixed.go
+++ b/template_adapter_mixed.go
@@ -46,8 +46,9 @@ func (engine *MixedEngine) ParseAndAdd(templateName string, templateSource strin
 		config.SetSection(mode)
 
 		templateEngineName := config.StringDefault(REVEL_TEMPLATE_ENGINE, "")
+		// preventing recursive load template engine.
 		if MIXED_TEMPLATE == templateEngineName {
-			templateEngineName = GO_TEMPLATE
+			templateEngineName = ""
 		}
 		templateSet, err = engine.loader.CreateTemplateEngine(templateEngineName)
 		if nil != err {

--- a/template_adapter_mixed.go
+++ b/template_adapter_mixed.go
@@ -9,6 +9,17 @@ import (
 	robfigConfig "github.com/robfig/config"
 )
 
+var RevelModules = []string{"github.com/revel/modules/"}
+
+func isRevelModules(slashPath string) bool {
+	for _, module := range RevelModules {
+		if strings.Contains(slashPath, module) {
+			return true
+		}
+	}
+	return false
+}
+
 type MixedEngine struct {
 	loader                     *TemplateLoader
 	templateSetsByPath         map[string]TemplateEngine
@@ -55,10 +66,14 @@ func (engine *MixedEngine) ParseAndAdd(templateName string, templateSource strin
 		var templateEngineName string
 		slashPath := filepath.ToSlash(basePath)
 		if strings.HasSuffix(slashPath, "/app/views") {
-			var err *Error
-			templateEngineName, err = engine.templateEngineNameFrom(templateName, basePath)
-			if nil != err {
-				return err
+			if isRevelModules(slashPath) {
+				templateEngineName = GO_TEMPLATE
+			} else {
+				var err *Error
+				templateEngineName, err = engine.templateEngineNameFrom(templateName, basePath)
+				if nil != err {
+					return err
+				}
 			}
 		} else if slashPath == filepath.ToSlash(path.Join(RevelPath, "templates")) {
 			templateEngineName = GO_TEMPLATE

--- a/template_adapter_mixed.go
+++ b/template_adapter_mixed.go
@@ -45,7 +45,11 @@ func (engine *MixedEngine) ParseAndAdd(templateName string, templateSource strin
 		}
 		config.SetSection(mode)
 
-		templateSet, err = engine.loader.CreateTemplateEngine(config.StringDefault(REVEL_TEMPLATE_ENGINE, ""))
+		templateEngineName := config.StringDefault(REVEL_TEMPLATE_ENGINE, "")
+		if MIXED_TEMPLATE == templateEngineName {
+			templateEngineName = GO_TEMPLATE
+		}
+		templateSet, err = engine.loader.CreateTemplateEngine(templateEngineName)
 		if nil != err {
 			return &Error{
 				Title:       "Panic (Template Loader)",

--- a/template_adapter_mixed.go
+++ b/template_adapter_mixed.go
@@ -1,0 +1,81 @@
+package revel
+
+import (
+	"path/filepath"
+	"strings"
+
+	revConfig "github.com/revel/revel/config"
+	robfigConfig "github.com/robfig/config"
+)
+
+type MixedEngine struct {
+	loader                     *TemplateLoader
+	templateSetsByPath         map[string]TemplateEngine
+	templateSetsByTemplateName map[string]TemplateEngine
+}
+
+func (engine *MixedEngine) ParseAndAdd(templateName string, templateSource string, basePath string) *Error {
+	templateSet := engine.templateSetsByPath[basePath]
+	if nil == templateSet {
+		confPath := filepath.ToSlash(basePath)
+		if strings.HasSuffix(confPath, "/app/views") {
+			confPath = filepath.ToSlash(filepath.Join(strings.TrimSuffix(confPath, "/app/views"), "conf"))
+		}
+
+		// Load app.conf from confPath
+		config, err := revConfig.LoadContext("app.conf", []string{confPath})
+		if err != nil || config == nil {
+			return &Error{
+				Title:       "Panic (Template Loader)",
+				Description: "Failed to load template(" + templateName + "): cann't load " + confPath + "/app.conf:" + err.Error(),
+			}
+		}
+
+		// Ensure that the selected runmode appears in app.conf.
+		// If empty string is passed as the mode, treat it as "DEFAULT"
+		mode := RunMode
+		if mode == "" {
+			mode = robfigConfig.DEFAULT_SECTION
+		}
+		if !config.HasSection(mode) {
+			return &Error{
+				Title:       "Panic (Template Loader)",
+				Description: "Failed to load template(" + templateName + "): cann't load " + confPath + "/app.conf: No mode found: " + mode,
+			}
+		}
+		config.SetSection(mode)
+
+		templateSet, err = engine.loader.CreateTemplateEngine(config.StringDefault(REVEL_TEMPLATE_ENGINE, ""))
+		if nil != err {
+			return &Error{
+				Title:       "Panic (Template Loader)",
+				Description: "Failed to load template(" + templateName + "): " + err.Error(),
+			}
+		}
+	}
+
+	err := templateSet.ParseAndAdd(templateName, templateSource, basePath)
+	if nil != err {
+		return err
+	}
+	engine.templateSetsByTemplateName[strings.ToLower(templateName)] = templateSet
+	return nil
+}
+
+func (engine *MixedEngine) Lookup(templateName string) Template {
+	templateSet := engine.templateSetsByTemplateName[strings.ToLower(templateName)]
+	if nil == templateSet {
+		return nil
+	}
+	return templateSet.Lookup(templateName)
+}
+
+func init() {
+	TemplateEngines[MIXED_TEMPLATE] = func(loader *TemplateLoader) (TemplateEngine, error) {
+		return &MixedEngine{
+			loader:                     loader,
+			templateSetsByPath:         make(map[string]TemplateEngine),
+			templateSetsByTemplateName: make(map[string]TemplateEngine),
+		}, nil
+	}
+}

--- a/testdata/conf/app.conf
+++ b/testdata/conf/app.conf
@@ -29,6 +29,8 @@ build.tags=gorp
 module.jobs=github.com/revel/modules/jobs
 module.static=github.com/revel/modules/static
 
+template.engine=go
+
 [dev]
 mode.dev=true
 watch=true


### PR DESCRIPTION
I want to use [pongo2](https://github.com/flosch/pongo2) in the revel project.
I redesign https://github.com/revel/revel/pull/506 and push it.

my samples project is https://github.com/runner-mei/revel_samples/tree/master/booking
my pongo2 module project is https://github.com/runner-mei/revel_modules/tree/master/pongo2/app

revel/cmd patch is  https://github.com/revel/cmd/pull/37
