### PR TITLE
Add `application/javascript` to accepted headers

### DIFF
--- a/http.go
+++ b/http.go
@@ -79,7 +79,8 @@ func ResolveFormat(req *http.Request) string {
 		strings.Contains(accept, "text/html"):
 		return "html"
 	case strings.Contains(accept, "application/json"),
-		strings.Contains(accept, "text/javascript"):
+		strings.Contains(accept, "text/javascript"),
+		strings.Contains(accept, "application/javascript"):
 		return "json"
 	case strings.Contains(accept, "application/xml"),
 		strings.Contains(accept, "text/xml"):


### PR DESCRIPTION
`application/javascript` is an accepted MIME type for JavaScript and
JSON document, and it's more popular than `text/javascript`.
See http://www.iana.org/assignments/media-types/application/javascript.