### PR TITLE
Remove sleep from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,10 @@ script:
   - revel package my/testapp
 
   # Build & run the sample apps
-  # Sleep between tests to avoid spurious "address already in use" failures.
   - revel test github.com/revel/samples/booking
-  - sleep 30
   - revel test github.com/revel/samples/chat
-  - sleep 30
   - revel test github.com/revel/samples/facebook-oauth2
-  - sleep 30
   - revel test github.com/revel/samples/twitter-oauth
-  - sleep 30
   - revel test github.com/revel/samples/validation
-  - sleep 30
   - revel test github.com/revel/samples/persona
-  - sleep 30
   - revel test github.com/revel/samples/upload


### PR DESCRIPTION
It takes long time for CI testing because of `sleep 30`. So I removed that and it looks fine.
What do you think?

[Related issue](https://github.com/revel/revel/issues/613)

