### PR TITLE
create the log directory if it does not already exist

### DIFF
--- a/revel.go
+++ b/revel.go
@@ -227,6 +227,17 @@ func getLogger(name string) *log.Logger {
 			output = os.DevNull
 		}
 
+		logPath := filepath.Dir(output)
+		if _, err := os.Stat(logPath); err != nil {
+			if os.IsNotExist(err) {
+				if err := os.MkdirAll(logPath, 0777); err != nil {
+					log.Fatalln("Failed to create log dir", output, ":", err)
+				}
+			} else {
+				log.Fatalln("Failed to stat log dir", output, ":", err)
+			}
+		}
+
 		file, err := os.OpenFile(output, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		if err != nil {
 			log.Fatalln("Failed to open log file", output, ":", err)


### PR DESCRIPTION
creates log's dir with any necessary parents, filemod is 0777
example in app config:
log.info.output  = log/%(app.name)s.log