### PR TITLE
Fix existing comments that golint complains about.

### DIFF
--- a/cache/memcached.go
+++ b/cache/memcached.go
@@ -8,7 +8,7 @@ import (
 	"github.com/revel/revel"
 )
 
-// Wraps the Memcached client to meet the Cache interface.
+// MemcachedCache wraps the Memcached client to meet the Cache interface.
 type MemcachedCache struct {
 	*memcache.Client
 	defaultExpiration time.Duration
@@ -87,7 +87,7 @@ func (c MemcachedCache) invoke(f func(*memcache.Client, *memcache.Item) error,
 	}))
 }
 
-// Implement a Getter on top of the returned item map.
+// ItemMapGetter implements a Getter on top of the returned item map.
 type ItemMapGetter map[string]*memcache.Item
 
 func (g ItemMapGetter) Get(key string, ptrValue interface{}) error {

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -7,12 +7,13 @@ import (
 	"github.com/revel/revel"
 )
 
-// Wraps the Redis client to meet the Cache interface.
+// RedisCache wraps the Redis client to meet the Cache interface.
 type RedisCache struct {
 	pool              *redis.Pool
 	defaultExpiration time.Duration
 }
 
+// NewRedisCache returns a new RedisCache with given parameters
 // until redigo supports sharding/clustering, only one host will be in hostList
 func NewRedisCache(host string, password string, defaultExpiration time.Duration) RedisCache {
 	var pool = &redis.Pool{
@@ -253,7 +254,7 @@ func (c RedisCache) invoke(f func(string, ...interface{}) (interface{}, error),
 	return err
 }
 
-// Implement a Getter on top of the returned item map.
+// RedisItemMapGetter implements a Getter on top of the returned item map.
 type RedisItemMapGetter map[string][]byte
 
 func (g RedisItemMapGetter) Get(key string, ptrValue interface{}) error {

--- a/controller.go
+++ b/controller.go
@@ -258,8 +258,8 @@ func (c *Controller) Redirect(val interface{}, args ...interface{}) Result {
 	return &RedirectToActionResult{val}
 }
 
-// Perform a message lookup for the given message name using the given arguments
-// using the current language defined for this controller.
+// Message performs a lookup for the given message name using the given
+// arguments using the current language defined for this controller.
 //
 // The current language is set by the i18n plugin.
 func (c *Controller) Message(message string, args ...interface{}) (value string) {

--- a/intercept.go
+++ b/intercept.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-// An "interceptor" is functionality invoked by the framework BEFORE or AFTER
+// An InterceptorFunc is functionality invoked by the framework BEFORE or AFTER
 // an action.
 //
 // An interceptor may optionally return a Result (instead of nil).  Depending on

--- a/skeleton/app/init.go
+++ b/skeleton/app/init.go
@@ -25,11 +25,11 @@ func init() {
 	// revel.OnAppStart(FillCache)
 }
 
+// HeaderFilter adds common security headers
 // TODO turn this into revel.HeaderFilter
 // should probably also have a filter for CSRF
 // not sure if it can go in the same filter or not
 var HeaderFilter = func(c *revel.Controller, fc []revel.Filter) {
-	// Add some common security headers
 	c.Response.Out.Header().Add("X-Frame-Options", "SAMEORIGIN")
 	c.Response.Out.Header().Add("X-XSS-Protection", "1; mode=block")
 	c.Response.Out.Header().Add("X-Content-Type-Options", "nosniff")

--- a/template.go
+++ b/template.go
@@ -44,7 +44,7 @@ var invalidSlugPattern = regexp.MustCompile(`[^a-z0-9 _-]`)
 var whiteSpacePattern = regexp.MustCompile(`\s+`)
 
 var (
-	// The functions available for use in the templates.
+	// TemplateFuncs is the collection of functions available in templates
 	TemplateFuncs = map[string]interface{}{
 		"url": ReverseURL,
 		"set": func(renderArgs map[string]interface{}, key string, value interface{}) template.JS {

--- a/testing/testsuite.go
+++ b/testing/testsuite.go
@@ -63,7 +63,7 @@ func (t *TestSuite) NewTestRequest(req *http.Request) *TestRequest {
 	}
 }
 
-// Return the address and port of the server, e.g. "127.0.0.1:8557"
+// Host returns the address and port of the server, e.g. "127.0.0.1:8557"
 func (t *TestSuite) Host() string {
 	if revel.Server.Addr[0] == ':' {
 		return "127.0.0.1" + revel.Server.Addr
@@ -71,7 +71,7 @@ func (t *TestSuite) Host() string {
 	return revel.Server.Addr
 }
 
-// Return the base http/https URL of the server, e.g. "http://127.0.0.1:8557".
+// BaseUrl returns the base http/https URL of the server, e.g. "http://127.0.0.1:8557".
 // The scheme is set to https if http.ssl is set to true in the configuration file.
 func (t *TestSuite) BaseUrl() string {
 	if revel.HTTPSsl {
@@ -80,18 +80,18 @@ func (t *TestSuite) BaseUrl() string {
 	return "http://" + t.Host()
 }
 
-// Return the base websocket URL of the server, e.g. "ws://127.0.0.1:8557"
+// WebSocketUrl returns the base websocket URL of the server, e.g. "ws://127.0.0.1:8557"
 func (t *TestSuite) WebSocketUrl() string {
 	return "ws://" + t.Host()
 }
 
-// Issue a GET request to the given path and store the result in Response and
-// ResponseBody.
+// Get issues a GET request to the given path and stores the result in Response
+// and ResponseBody.
 func (t *TestSuite) Get(path string) {
 	t.GetCustom(t.BaseUrl() + path).Send()
 }
 
-// Return a GET request to the given uri in a form of its wrapper.
+// GetCustom returns a GET request to the given URI in a form of its wrapper.
 func (t *TestSuite) GetCustom(uri string) *TestRequest {
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
@@ -100,13 +100,14 @@ func (t *TestSuite) GetCustom(uri string) *TestRequest {
 	return t.NewTestRequest(req)
 }
 
-// Issue a DELETE request to the given path and store the result in Response and
-// ResponseBody.
+// Delete issues a DELETE request to the given path and stores the result in
+// Response and ResponseBody.
 func (t *TestSuite) Delete(path string) {
 	t.DeleteCustom(t.BaseUrl() + path).Send()
 }
 
-// Return a DELETE request to the given uri in a form of its wrapper.
+// DeleteCustom returns a DELETE request to the given URI in a form of its
+// wrapper.
 func (t *TestSuite) DeleteCustom(uri string) *TestRequest {
 	req, err := http.NewRequest("DELETE", uri, nil)
 	if err != nil {
@@ -115,14 +116,14 @@ func (t *TestSuite) DeleteCustom(uri string) *TestRequest {
 	return t.NewTestRequest(req)
 }
 
-// Issue a PUT request to the given path, sending the given Content-Type and
-// data, and store the result in Response and ResponseBody.  "data" may be nil.
+// Put issues a PUT request to the given path, sending the given Content-Type
+// and data, storing the result in Response and ResponseBody. "data" may be nil.
 func (t *TestSuite) Put(path string, contentType string, reader io.Reader) {
 	t.PutCustom(t.BaseUrl()+path, contentType, reader).Send()
 }
 
-// Return a PUT request to the given uri with specified Content-Type and data
-// in a form of wrapper. "data" may be nil.
+// PutCustom returns a PUT request to the given URI with specified Content-Type
+// and data in a form of wrapper. "data" may be nil.
 func (t *TestSuite) PutCustom(uri string, contentType string, reader io.Reader) *TestRequest {
 	req, err := http.NewRequest("PUT", uri, reader)
 	if err != nil {
@@ -132,26 +133,27 @@ func (t *TestSuite) PutCustom(uri string, contentType string, reader io.Reader) 
 	return t.NewTestRequest(req)
 }
 
-// Issue a PUT request to the given path as a form put of the given key and
-// values, and store the result in Response and ResponseBody.
+// PutForm issues a PUT request to the given path as a form put of the given key
+// and values, and stores the result in Response and ResponseBody.
 func (t *TestSuite) PutForm(path string, data url.Values) {
 	t.PutFormCustom(t.BaseUrl()+path, data).Send()
 }
 
-// Return a PUT request to the given uri as a form put of the given key and values.
-// The request is in a form of TestRequest wrapper.
+// PutFormCustom returns a PUT request to the given URI as a form put of the
+// given key and values. The request is in a form of TestRequest wrapper.
 func (t *TestSuite) PutFormCustom(uri string, data url.Values) *TestRequest {
 	return t.PutCustom(uri, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
 }
 
-// Issue a PATCH request to the given path, sending the given Content-Type and
-// data, and store the result in Response and ResponseBody.  "data" may be nil.
+// Patch issues a PATCH request to the given path, sending the given
+// Content-Type and data, and stores the result in Response and ResponseBody.
+// "data" may be nil.
 func (t *TestSuite) Patch(path string, contentType string, reader io.Reader) {
 	t.PatchCustom(t.BaseUrl()+path, contentType, reader).Send()
 }
 
-// Return a PATCH request to the given uri with specified Content-Type and data
-// in a form of wrapper. "data" may be nil.
+// PatchCustom returns a PATCH request to the given URI with specified
+// Content-Type and data in a form of wrapper. "data" may be nil.
 func (t *TestSuite) PatchCustom(uri string, contentType string, reader io.Reader) *TestRequest {
 	req, err := http.NewRequest("PATCH", uri, reader)
 	if err != nil {
@@ -161,14 +163,14 @@ func (t *TestSuite) PatchCustom(uri string, contentType string, reader io.Reader
 	return t.NewTestRequest(req)
 }
 
-// Issue a POST request to the given path, sending the given Content-Type and
-// data, and store the result in Response and ResponseBody.  "data" may be nil.
+// Post issues a POST request to the given path, sending the given Content-Type
+// and data, storing the result in Response and ResponseBody. "data" may be nil.
 func (t *TestSuite) Post(path string, contentType string, reader io.Reader) {
 	t.PostCustom(t.BaseUrl()+path, contentType, reader).Send()
 }
 
-// Return a POST request to the given uri with specified Content-Type and data
-// in a form of wrapper. "data" may be nil.
+// PostCustom returns a POST request to the given URI with specified
+// Content-Type and data in a form of wrapper. "data" may be nil.
 func (t *TestSuite) PostCustom(uri string, contentType string, reader io.Reader) *TestRequest {
 	req, err := http.NewRequest("POST", uri, reader)
 	if err != nil {
@@ -178,26 +180,26 @@ func (t *TestSuite) PostCustom(uri string, contentType string, reader io.Reader)
 	return t.NewTestRequest(req)
 }
 
-// Issue a POST request to the given path as a form post of the given key and
-// values, and store the result in Response and ResponseBody.
+// PostForm issues a POST request to the given path as a form post of the given
+// key and values, and stores the result in Response and ResponseBody.
 func (t *TestSuite) PostForm(path string, data url.Values) {
 	t.PostFormCustom(t.BaseUrl()+path, data).Send()
 }
 
-// Return a POST request to the given uri as a form post of the given key and values.
-// The request is in a form of TestRequest wrapper.
+// PostFormCustom returns a POST request to the given URI as a form post of the
+// given key and values. The request is in a form of TestRequest wrapper.
 func (t *TestSuite) PostFormCustom(uri string, data url.Values) *TestRequest {
 	return t.PostCustom(uri, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
 }
 
-// Issue a multipart request to the given path sending given params and files,
-// and store the result in Response and ResponseBody.
+// PostFile issues a multipart request to the given path sending given params
+// and files, and stores the result in Response and ResponseBody.
 func (t *TestSuite) PostFile(path string, params url.Values, filePaths url.Values) {
 	t.PostFileCustom(t.BaseUrl()+path, params, filePaths).Send()
 }
 
-// Return a multipart request to the given uri in a form of its wrapper
-// with the given params and files.
+// PostFileCustom returns a multipart request to the given URI in a form of its
+// wrapper with the given params and files.
 func (t *TestSuite) PostFileCustom(uri string, params url.Values, filePaths url.Values) *TestRequest {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -220,7 +222,7 @@ func (t *TestSuite) PostFileCustom(uri string, params url.Values, filePaths url.
 	return t.PostCustom(uri, writer.FormDataContentType(), body)
 }
 
-// Issue any request and read the response. If successful, the caller may
+// Send issues any request and reads the response. If successful, the caller may
 // examine the Response and ResponseBody properties. Session data will be
 // added to the request cookies for you.
 func (r *TestRequest) Send() {
@@ -228,8 +230,8 @@ func (r *TestRequest) Send() {
 	r.MakeRequest()
 }
 
-// Issue any request and read the response. If successful, the caller may
-// examine the Response and ResponseBody properties. You will need to
+// MakeRequest issues any request and read the response. If successful, the
+// caller may examine the Response and ResponseBody properties. You will need to
 // manage session / cookie data manually
 func (r *TestRequest) MakeRequest() {
 	var err error
@@ -250,7 +252,7 @@ func (r *TestRequest) MakeRequest() {
 	}
 }
 
-// Create a websocket connection to the given path and return the connection
+// WebSocket creates a websocket connection to the given path and returns it
 func (t *TestSuite) WebSocket(path string) *websocket.Conn {
 	origin := t.BaseUrl() + "/"
 	url := t.WebSocketUrl() + path
@@ -308,21 +310,21 @@ func (t *TestSuite) Assertf(exp bool, formatStr string, args ...interface{}) {
 	}
 }
 
-// Assert that the response contains the given string.
+// AssertContains asserts that the response contains the given string.
 func (t *TestSuite) AssertContains(s string) {
 	if !bytes.Contains(t.ResponseBody, []byte(s)) {
 		panic(fmt.Errorf("Assertion failed. Expected response to contain %s", s))
 	}
 }
 
-// Assert that the response does not contain the given string.
+// AssertNotContains asserts that the response does not contain the given string.
 func (t *TestSuite) AssertNotContains(s string) {
 	if bytes.Contains(t.ResponseBody, []byte(s)) {
 		panic(fmt.Errorf("Assertion failed. Expected response not to contain %s", s))
 	}
 }
 
-// Assert that the response matches the given regular expression.
+// AssertContainsRegex asserts that the response matches the given regular expression.
 func (t *TestSuite) AssertContainsRegex(regex string) {
 	r := regexp.MustCompile(regex)
 


### PR DESCRIPTION
Related to cleanup efforts in #1057 

E.g.
testing/testsuite.go:231:1:warning: comment on exported method
TestRequest.MakeRequest should be of the form "MakeRequest ..." (golint)