### PR TITLE
Update bootstrap alert in flash.html

### DIFF
--- a/skeleton/app/views/flash.html
+++ b/skeleton/app/views/flash.html
@@ -5,7 +5,7 @@
 {{end}}
 
 {{if or .errors .flash.error}}
-<div class="alert alert-error">
+<div class="alert alert-danger">
 	{{if .flash.error}}
 		{{.flash.error}}
 	{{end}}


### PR DESCRIPTION
"alert-error" has been changed to "alert-danger" since bootstrap 3.X (see http://getbootstrap.com/migration/). This skeleton app currently uses bootstrap 3.3.6.