### PR TITLE
fix #1095 param map overwrite priority

### DIFF
--- a/params.go
+++ b/params.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2016 The Revel Framework Authors, All rights reserved.
+// Copyright (c) 2012-2017 The Revel Framework Authors, All rights reserved.
 // Revel Framework source code and usage is governed by a MIT style
 // license that can be found in the LICENSE file.
 
@@ -97,20 +97,27 @@ func (p *Params) calcValues() url.Values {
 		return p.Form
 	}
 
-	// Copy everything into the same map.
+	// Copy everything into a param map,
+	// order of priority is least to most trusted
 	values := make(url.Values, numParams)
-	for k, v := range p.Fixed {
-		values[k] = append(values[k], v...)
-	}
+
+	// ?query vars first
 	for k, v := range p.Query {
 		values[k] = append(values[k], v...)
 	}
-	for k, v := range p.Route {
-		values[k] = append(values[k], v...)
-	}
+	// form vars overwrite
 	for k, v := range p.Form {
 		values[k] = append(values[k], v...)
 	}
+	// :/path vars overwrite
+	for k, v := range p.Route {
+		values[k] = append(values[k], v...)
+	}
+	// fixed vars overwrite
+	for k, v := range p.Fixed {
+		values[k] = append(values[k], v...)
+	}
+
 	return values
 }
 


### PR DESCRIPTION
Its mainly explained in https://github.com/revel/revel/issues/503#issuecomment-65252825 - Excerpt below

## Problem

The problem is that the order in which all the parameters of different types are appended is not documented and defined explicitly.

#503 has become possible because for Static.Serve(prefix, filepath string) only first prefix's value from c.Params is binded:
```
c.Params = url.Values {
    "prefix": []url{"some_param_from_query", "public"},
}
```
Before #504 it was query parameter. Now it is a fixed parameter.

But we still should define what we are trying to get when we are appending parameters of different types both safe and unsafe ones together.

If it brings any value (and it looks like it does) we should better document the order (probably, we need to rethink and change it) and the fact that c.Params can never be trusted (#809). c.FixedParams should be used by framework users and module developers when safe param from routes file is expected.