### PR TITLE
changes cookie.secure default to be based on HTTP SSL

### DIFF
--- a/filterconfig.go
+++ b/filterconfig.go
@@ -66,7 +66,7 @@ func newFilterConfigurator(controllerName, methodName string) FilterConfigurator
 
 // FilterController returns a configurator for the filters applied to all
 // actions on the given controller instance.  For example:
-//   FilterAction(MyController{})
+//   FilterController(MyController{})
 func FilterController(controllerInstance interface{}) FilterConfigurator {
 	t := reflect.TypeOf(controllerInstance)
 	for t.Kind() == reflect.Ptr {

--- a/revel.go
+++ b/revel.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/agtorre/gocolorize"
 	"github.com/revel/config"
+	"net/http"
 )
 
 const (
@@ -204,7 +205,7 @@ func Init(mode, importPath, srcPath string) {
 	AppRoot = Config.StringDefault("app.root", "")
 	CookiePrefix = Config.StringDefault("cookie.prefix", "REVEL")
 	CookieDomain = Config.StringDefault("cookie.domain", "")
-	CookieSecure = Config.BoolDefault("cookie.secure", !DevMode)
+	CookieSecure = Config.BoolDefault("cookie.secure", HTTPSsl)
 	TemplateDelims = Config.StringDefault("template.delimiters", "")
 	if secretStr := Config.StringDefault("app.secret", ""); secretStr != "" {
 		secretKey = []byte(secretStr)

--- a/revel.go
+++ b/revel.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/agtorre/gocolorize"
 	"github.com/revel/config"
-	"net/http"
 )
 
 const (


### PR DESCRIPTION
changes cookie.secure default to depend on HTTP SSL setting
should only be enabled when SSL is enabled in revel
also, fixes name of function in comment