### PR TITLE
Fix constant DEFAULT_SECTION to DefaultSection

### DIFF
--- a/revel.go
+++ b/revel.go
@@ -177,7 +177,7 @@ func Init(mode, importPath, srcPath string) {
 	// Ensure that the selected runmode appears in app.conf.
 	// If empty string is passed as the mode, treat it as "DEFAULT"
 	if mode == "" {
-		mode = config.DEFAULT_SECTION
+		mode = config.DefaultSection
 	}
 	if !Config.HasSection(mode) {
 		log.Fatalln("app.conf: No mode found:", mode)


### PR DESCRIPTION
The installation throws the following error.

go get github.com/revel/revel
#github.com/revel/revel
src/github.com/revel/revel/revel.go:180: undefined: config.DEFAULT_SECTION

https://github.com/revel/config/commit/662332b741dd464a886ab0901379c02b9bc5dc30#diff-4cecda73b06e0c180acae5250e973afeL30