### PR TITLE
param map overwrite priority

### DIFF
--- a/params.go
+++ b/params.go
@@ -107,15 +107,15 @@ func (p *Params) calcValues() url.Values {
 	}
 	// form vars overwrite
 	for k, v := range p.Form {
-		values[k] = append(values[k], v...)
+		values[k] = v
 	}
 	// :/path vars overwrite
 	for k, v := range p.Route {
-		values[k] = append(values[k], v...)
+		values[k] = v
 	}
 	// fixed vars overwrite
 	for k, v := range p.Fixed {
-		values[k] = append(values[k], v...)
+		values[k] = v
 	}
 
 	return values


### PR DESCRIPTION
This pull-req fix the problem that Fixed parameters can be overwritten with Get parameters.

Here is the reproduction scenario, `routes`

```
GET     /hoge            App.Hoge("fixed")
```

and controller

```go
func (c App) Hoge(param string) revel.Result {
	fmt.Println(param)
	return c.Render()
}
```

and url

```
http://localhost:9000/hoge?param=get
```

exptected output: `fixed`
but actual: `get`

Issue #1095 and pr #1126 change the order of params priority, but insufficient.
So this pr is overwrite low priority params by higher priority params.