### PR TITLE
Based on the "extension" of the requested path, return content type

### DIFF
--- a/http.go
+++ b/http.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"golang.org/x/net/websocket"
+	"path/filepath"
 )
 
 // Request Revel's HTTP request object structure
@@ -78,6 +79,18 @@ func ResolveContentType(req *http.Request) string {
 // returning a default of "html" when Accept header cannot be mapped to a
 // value above.
 func ResolveFormat(req *http.Request) string {
+	ext := strings.ToLower(filepath.Ext(req.URL.Path))
+	switch ext {
+	case ".html":
+		return "html"
+	case ".json":
+		return "json"
+	case ".xml":
+		return "xml"
+	case ".txt":
+		return "txt"
+	}
+
 	accept := req.Header.Get("accept")
 
 	switch {


### PR DESCRIPTION
Based on the "extension" of the requested path, returns an appropriate content type

closes #963, #1045