### PR TITLE
Added method matching when doing a reverse route lookup

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -304,7 +304,7 @@ func (c *Controller) SetTypeAction(controllerName, methodName string, typeOfCont
 
 	// Note method name is case insensitive search
 	if c.MethodType = c.Type.Method(methodName); c.MethodType == nil {
-		return errors.New("revel/controller: failed to find action " + methodName)
+		return errors.New("revel/controller: failed to find action " + controllerName + "." + methodName)
 	}
 
 	c.Name, c.MethodName = c.Type.Type.Name(), c.MethodType.Name

--- a/router.go
+++ b/router.go
@@ -137,7 +137,7 @@ func NewRoute(moduleSource *Module, method, path, action, fixedArgs, routesPath 
 
 			// The same action path could be used for multiple routes (like the Static.Serve)
 		} else {
-			ERROR.Panicf("Failed to find controller for route path action %s \n%#v\n", path+"?"+r.Action,actionPathCacheMap)
+			ERROR.Panicf("Failed to find controller for route path action %s \n%#v\n", path+"?"+r.Action, actionPathCacheMap)
 		}
 	}
 	return
@@ -291,7 +291,7 @@ func splitActionPath(actionPathData *ActionPathData, actionPath string, useCache
 		typeOfController                                        *ControllerType
 	)
 	actionSplit := strings.Split(actionPath, ".")
-	if actionPathData!=nil {
+	if actionPathData != nil {
 		foundModuleSource = actionPathData.ModuleSource
 	}
 	if len(actionSplit) == 2 {
@@ -310,13 +310,13 @@ func splitActionPath(actionPathData *ActionPathData, actionPath string, useCache
 			}
 			controllerName = controllerName[i+1:]
 			// Check for the type of controller
-			typeOfController = foundModuleSource.ControllerByName(controllerName,methodName)
+			typeOfController = foundModuleSource.ControllerByName(controllerName, methodName)
 			found = typeOfController != nil
 		} else if controllerName[0] != ':' {
 			// First attempt to find the controller in the module source
-			if foundModuleSource!=nil {
-				typeOfController = foundModuleSource.ControllerByName(controllerName,methodName)
-				if typeOfController!=nil {
+			if foundModuleSource != nil {
+				typeOfController = foundModuleSource.ControllerByName(controllerName, methodName)
+				if typeOfController != nil {
 					controllerNamespace = typeOfController.Namespace
 				}
 			}
@@ -380,7 +380,7 @@ func splitActionPath(actionPathData *ActionPathData, actionPath string, useCache
 			}
 		}
 		actionPathData.TypeOfController = foundModuleSource.ControllerByName(controllerName, "")
-		if actionPathData.TypeOfController == nil && actionPathData.ControllerName[0]!=':' {
+		if actionPathData.TypeOfController == nil && actionPathData.ControllerName[0] != ':' {
 			WARN.Printf("Router: No controller found for %s %#v", foundModuleSource.Namespace()+controllerName, controllers)
 		}
 
@@ -606,18 +606,20 @@ func (router *Router) Reverse(action string, argValues map[string]string) (ad *A
 					// Wildcard match in same module space
 					pathData.Route = route
 					break
-				} else if route.ActionPath() == pathData.ModuleSource.Namespace()+pathData.ControllerName {
+				} else if route.ActionPath() == pathData.ModuleSource.Namespace()+pathData.ControllerName &&
+					(route.Method[0] == ':' || route.Method == pathData.MethodName) {
 					// Action path match
 					pathData.Route = route
 					break
-				} else if route.ControllerName == pathData.ControllerName {
+				} else if route.ControllerName == pathData.ControllerName &&
+					(route.Method[0] == ':' || route.Method == pathData.MethodName) {
 					// Controller name match
 					possibleRoute = route
 				}
 			}
 			if pathData.Route == nil && possibleRoute != nil {
 				pathData.Route = possibleRoute
-				WARN.Printf("For reverse action %s matched path route %#v", action, possibleRoute)
+				WARN.Printf("For a url reverse a match was based on  %s matched path to route %#v ", action, possibleRoute)
 			}
 			if pathData.Route != nil {
 				TRACE.Printf("Reverse Storing recognized action path %s for route %#v\n", action, pathData.Route)


### PR DESCRIPTION
Reverse routes was using the first controller in the route map for matching when determining the reverse route. This caused issues if the controller was partially defined in the route file. I modified the route check to validate against the MethodName as well

