### PR TITLE
Allow binder to bind struct map (replacement for pr 998)

### DIFF
--- a/binder.go
+++ b/binder.go
@@ -432,13 +432,17 @@ func bindMap(params *Params, name string, typ reflect.Type) reflect.Value {
 		return result
 	}
 
-	for paramName, values := range params.Values {
-		if !strings.HasPrefix(paramName, name+"[") || paramName[len(paramName)-1] != ']' {
+	for paramName, _ := range params.Values {
+		suffix := paramName[len(name)+1:]
+		fieldName := nextKey(suffix)
+		if fieldName != "" {
+			fieldName = fieldName[:len(fieldName)-1]
+		}
+		if !strings.HasPrefix(paramName, name+"["+fieldName+"]") {
 			continue
 		}
 
-		key := paramName[len(name)+1 : len(paramName)-1]
-		result.SetMapIndex(BindValue(key, keyType), BindValue(values[0], valueType))
+		result.SetMapIndex(BindValue(fieldName, keyType), Bind(params, name+"["+fieldName+"]", valueType))
 	}
 	return result
 }

--- a/binder_test.go
+++ b/binder_test.go
@@ -84,6 +84,10 @@ var (
 		"m2[2]":           {"bar"},
 		"m3[a]":           {"1"},
 		"m3[b]":           {"2"},
+		"m4[a].ID":        {"1"},
+		"m4[a].Name":      {"foo"},
+		"m4[b].ID":        {"2"},
+		"m4[b].Name":      {"bar"},
 		"invalidInt":      {"xyz"},
 		"invalidInt2":     {""},
 		"invalidBool":     {"xyz"},
@@ -142,6 +146,7 @@ var binderTestCases = map[string]interface{}{
 	"m":  map[string]string{"a": "foo", "b": "bar"},
 	"m2": map[int]string{1: "foo", 2: "bar"},
 	"m3": map[string]int{"a": 1, "b": 2},
+	"m4": map[string]A{"a": A{ID: 1, Name: "foo"}, "b": A{ID: 2, Name: "bar"}},
 
 	// TODO: Tests that use TypeBinders
 


### PR DESCRIPTION
Replacement for PR that was not able to be merged #998
closes #997, #998

Updates the route tests to fix failing tests

### TODO

- [x] docs for [request param](http://revel.github.io/manual/parameters.html) 