### PR TITLE
Added template read and population

### DIFF
--- a/.codebeatsettings
+++ b/.codebeatsettings
@@ -1,5 +1,8 @@
 {
   "GOLANG": {
+  "ABC":[15, 25, 50, 70],
+  "BLOCK_NESTING":[5, 6, 7, 8],
+  "CYCLO":[20, 30, 45, 60],
     "TOO_MANY_IVARS": [15, 18, 20, 25],
     "TOO_MANY_FUNCTIONS": [20, 30, 40, 50],
     "TOTAL_COMPLEXITY": [150, 250, 400, 500],

--- a/controller.go
+++ b/controller.go
@@ -198,6 +198,11 @@ func (c *Controller) RenderTemplate(templatePath string) Result {
 	}
 }
 
+// TemplateOutput returns the result of the template rendered using the controllers ViewArgs.
+func (c *Controller) TemplateOutput(templatePath string) (data []byte,err error)  {
+	return TemplateOutputArgs(templatePath,c.ViewArgs)
+}
+
 // RenderJSON uses encoding/json.Marshal to return JSON to the client.
 func (c *Controller) RenderJSON(o interface{}) Result {
 	c.setStatusIfNil(http.StatusOK)

--- a/panic.go
+++ b/panic.go
@@ -5,7 +5,6 @@
 package revel
 
 import (
-	"github.com/revel/revel/logger"
 	"net/http"
 	"runtime/debug"
 )
@@ -25,7 +24,7 @@ func PanicFilter(c *Controller, fc []Filter) {
 // It cleans up the stack trace, logs it, and displays an error page.
 func handleInvocationPanic(c *Controller, err interface{}) {
 	error := NewErrorFromPanic(err)
-	utilLog.Error("PanicFilter: Caught panic", "error", err, "trace", logger.NewCallStack())
+	utilLog.Error("PanicFilter: Caught panic", "error", err, "stack", error.Stack)
 	if error == nil && DevMode {
 		// Only show the sensitive information in the debug stack trace in development mode, not production
 		c.Response.SetStatus(http.StatusInternalServerError)

--- a/template.go
+++ b/template.go
@@ -50,6 +50,25 @@ var invalidSlugPattern = regexp.MustCompile(`[^a-z0-9 _-]`)
 var whiteSpacePattern = regexp.MustCompile(`\s+`)
 var templateLog = RevelLog.New("section", "template")
 
+// TemplateOutputArgs returns the result of the template rendered using the passed in arguments.
+func TemplateOutputArgs(templatePath string, args map[string]interface{}) (data []byte,err error)  {
+	// Get the Template.
+	lang, _ := args[CurrentLocaleViewArg].(string)
+	template, err := MainTemplateLoader.TemplateLang(templatePath, lang)
+	if err != nil {
+		return nil, err
+	}
+	tr :=  &RenderTemplateResult{
+		Template: template,
+		ViewArgs: args,
+	}
+	b,err := tr.ToBytes()
+	if err!=nil {
+		return nil,err
+	}
+	return b.Bytes(), nil
+}
+
 func NewTemplateLoader(paths []string) *TemplateLoader {
 	loader := &TemplateLoader{
 		paths:         paths,


### PR DESCRIPTION
## Template fetch and render in one step
This PR returns the output of a rendered template. Useful for Json responses. Example application
```
	html,err := c.TemplateOutput("Response/jsonTemplate.html")
	if err!=nil {
		return c.RenderJSON(map[string]interface{}{"error": err.Error(), "success": false})
	}
	return c.RenderJSON(map[string]interface{}{"html": string(html), "success": true})
```

Added `controller.TemplateOut`, `revel.TemplateOutArgs` `controller.TemplateOut` uses the ViewArgs to pass to the template, `revel.TemplateOutArgs` requires both the template path and the args. Both source the template from revel.MainTemplate