### PR TITLE
Prerelease patche set

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -329,7 +329,7 @@ func (c *Controller) Redirect(val interface{}, args ...interface{}) Result {
 		}
 		return &RedirectToURLResult{fmt.Sprintf(url, args...)}
 	}
-	return &RedirectToActionResult{val}
+	return &RedirectToActionResult{val, args}
 }
 
 // This stats returns some interesting stats based on what is cached in memory

--- a/http.go
+++ b/http.go
@@ -22,7 +22,7 @@ import (
 // Request is Revel's HTTP request object structure
 type Request struct {
 	In              ServerRequest
-	ServerHeader    *RevelHeader
+	Header          *RevelHeader
 	ContentType     string
 	Format          string // "html", "xml", "json", or "txt"
 	AcceptLanguages AcceptLanguages
@@ -69,7 +69,7 @@ func NewResponse(w ServerResponse) (r *Response) {
 
 // NewRequest returns a Revel's HTTP request instance with given HTTP instance
 func NewRequest(r ServerRequest) *Request {
-	req := &Request{ServerHeader: &RevelHeader{}}
+	req := &Request{Header: &RevelHeader{}}
 	if r != nil {
 		req.SetRequest(r)
 	}
@@ -78,7 +78,7 @@ func NewRequest(r ServerRequest) *Request {
 func (req *Request) SetRequest(r ServerRequest) {
 	req.In = r
 	if h, e := req.In.Get(HTTP_SERVER_HEADER); e == nil {
-		req.ServerHeader.Server = h.(ServerHeader)
+		req.Header.Server = h.(ServerHeader)
 	}
 
 	req.URL,_ = req.GetValue(HTTP_URL).(*url.URL)
@@ -91,8 +91,8 @@ func (req *Request) SetRequest(r ServerRequest) {
 
 }
 func (req *Request) Cookie(key string) (ServerCookie, error) {
-	if req.ServerHeader.Server != nil {
-		return req.ServerHeader.Server.GetCookie(key)
+	if req.Header.Server != nil {
+		return req.Header.Server.GetCookie(key)
 	}
 	return nil, http.ErrNoCookie
 }
@@ -193,7 +193,7 @@ func (req *Request) Destroy() {
 	req.Method = ""
 	req.RemoteAddr = ""
 	req.Host = ""
-	req.ServerHeader.Destroy()
+	req.Header.Destroy()
 	req.URL = nil
 	req.Form = nil
 	req.MultipartForm = nil
@@ -221,15 +221,15 @@ func (resp *Response) Destroy() {
 
 // UserAgent returns the client's User-Agent header string.
 func (r *Request) UserAgent() string {
-	return r.ServerHeader.Get("User-Agent")
+	return r.Header.Get("User-Agent")
 }
 
 // Referer returns the client's Referer header string.
 func (req *Request) Referer() string {
-	return req.ServerHeader.Get("Referer")
+	return req.Header.Get("Referer")
 }
 func (req *Request) GetHttpHeader(key string) string {
-	return req.ServerHeader.Get(key)
+	return req.Header.Get(key)
 }
 
 func (r *Request) GetValue(key int) (value interface{}) {
@@ -329,7 +329,7 @@ func (h *RevelHeader) GetAll(key string) (values []string) {
 // If none is specified, returns "text/html" by default.
 func ResolveContentType(req *Request) string {
 
-	contentType := req.ServerHeader.Get("Content-Type")
+	contentType := req.Header.Get("Content-Type")
 	if contentType == "" {
 		return "text/html"
 	}
@@ -412,7 +412,7 @@ func (al AcceptLanguages) String() string {
 // See the HTTP header fields specification
 // (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4) for more details.
 func ResolveAcceptLanguage(req *Request) AcceptLanguages {
-	header := req.ServerHeader.Get("Accept-Language")
+	header := req.Header.Get("Accept-Language")
 	if header == "" {
 		return req.AcceptLanguages
 	}

--- a/intercept.go
+++ b/intercept.go
@@ -7,6 +7,7 @@ package revel
 import (
 	"log"
 	"reflect"
+	"sort"
 )
 
 // An InterceptorFunc is functionality invoked by the framework BEFORE or AFTER
@@ -68,11 +69,11 @@ type Interception struct {
 
 // Invoke performs the given interception.
 // val is a pointer to the App Controller.
-func (i Interception) Invoke(val reflect.Value) reflect.Value {
+func (i Interception) Invoke(val reflect.Value, target *reflect.Value) reflect.Value {
 	var arg reflect.Value
 	if i.function == nil {
 		// If it's an InterceptorMethod, then we have to pass in the target type.
-		arg = findTarget(val, i.target)
+		arg = *target
 	} else {
 		// If it's an InterceptorFunc, then the type must be *Controller.
 		// We can find that by following the embedded types up the chain.
@@ -115,7 +116,7 @@ func invokeInterceptors(when When, c *Controller) {
 	)
 
 	for _, intc := range getInterceptors(when, app) {
-		resultValue := intc.Invoke(app)
+		resultValue := intc.Interceptor.Invoke(app, &intc.Target)
 		if !resultValue.IsNil() {
 			result = resultValue.Interface().(Result)
 		}
@@ -154,6 +155,7 @@ func InterceptMethod(intc InterceptorMethod, when When) {
 		log.Fatalln("Interceptor method should have signature like",
 			"'func (c *AppController) example() revel.Result' but was", methodType)
 	}
+
 	interceptors = append(interceptors, &Interception{
 		When:     when,
 		method:   intc,
@@ -162,16 +164,40 @@ func InterceptMethod(intc InterceptorMethod, when When) {
 	})
 }
 
-func getInterceptors(when When, val reflect.Value) []*Interception {
-	result := []*Interception{}
+// This item is used to provide a sortable set to be returned to the caller. This ensures calls order is maintained
+//
+type interceptorItem struct {
+	Interceptor *Interception
+	Target reflect.Value
+	Level int
+}
+type interceptorItemList []*interceptorItem
+func (a interceptorItemList) Len() int           { return len(a) }
+func (a interceptorItemList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a interceptorItemList) Less(i, j int) bool { return a[i].Level < a[j].Level }
+type reverseInterceptorItemList []*interceptorItem
+func (a reverseInterceptorItemList) Len() int           { return len(a) }
+func (a reverseInterceptorItemList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a reverseInterceptorItemList) Less(i, j int) bool { return a[i].Level > a[j].Level }
+func getInterceptors(when When, val reflect.Value) interceptorItemList {
+	result := interceptorItemList{}
 	for _, intc := range interceptors {
 		if intc.When != when {
 			continue
 		}
 
-		if intc.interceptAll || findTarget(val, intc.target).IsValid() {
-			result = append(result, intc)
+		level,target := findTarget(val, intc.target)
+		if intc.interceptAll || target.IsValid() {
+			result = append(result, &interceptorItem{intc, target, level})
 		}
+	}
+
+	// Before is deepest to highest
+	if when ==BEFORE {
+		sort.Sort(result)
+	} else {
+		// Everything else is highest to deepest
+		sort.Sort(reverseInterceptorItemList(result))
 	}
 	return result
 }
@@ -179,21 +205,22 @@ func getInterceptors(when When, val reflect.Value) []*Interception {
 // Find the value of the target, starting from val and including embedded types.
 // Also, convert between any difference in indirection.
 // If the target couldn't be found, the returned Value will have IsValid() == false
-func findTarget(val reflect.Value, target reflect.Type) reflect.Value {
+func findTarget(val reflect.Value, target reflect.Type) (int, reflect.Value) {
 	// Look through the embedded types (until we reach the *revel.Controller at the top).
 	valueQueue := []reflect.Value{val}
+	level := 0
 	for len(valueQueue) > 0 {
 		val, valueQueue = valueQueue[0], valueQueue[1:]
 
 		// Check if val is of a similar type to the target type.
 		if val.Type() == target {
-			return val
+			return level,val
 		}
 		if val.Kind() == reflect.Ptr && val.Elem().Type() == target {
-			return val.Elem()
+			return level,val.Elem()
 		}
 		if target.Kind() == reflect.Ptr && target.Elem() == val.Type() {
-			return val.Addr()
+			return level,val.Addr()
 		}
 
 		// If we reached the *revel.Controller and still didn't find what we were
@@ -212,7 +239,8 @@ func findTarget(val reflect.Value, target reflect.Type) reflect.Value {
 				valueQueue = append(valueQueue, val.Field(i))
 			}
 		}
+		level --
 	}
 
-	return reflect.Value{}
+	return level, reflect.Value{}
 }

--- a/intercept_test.go
+++ b/intercept_test.go
@@ -77,8 +77,8 @@ func testInterceptorController(t *testing.T, appControllerPtr reflect.Value, met
 	}
 }
 
-func testInterception(t *testing.T, intc *Interception, arg reflect.Value) {
-	val := intc.Invoke(arg)
+func testInterception(t *testing.T, intc *interceptorItem, arg reflect.Value) {
+	val := intc.Interceptor.Invoke(arg, &intc.Target)
 	if !val.IsNil() {
 		t.Errorf("Failed (%v): Expected nil got %v", intc, val)
 	}

--- a/module.go
+++ b/module.go
@@ -47,8 +47,10 @@ func RegisterModuleInit(callback ModuleCallbackInterface) {
 func init() {
 	AddInitEventHandler(func(typeOf int, value interface{}) (responseOf int) {
 		if typeOf == REVEL_BEFORE_MODULES_LOADED {
-			Modules = []*Module{}
+			Modules = []*Module{appModule}
+			appModule.Path = AppPath
 		}
+
 		return
 	})
 }
@@ -83,7 +85,7 @@ func (m *Module) AddController(ct *ControllerType) {
 // Only to be used on initialization
 func ModuleFromPath(path string, addGopathToPath bool) (module *Module) {
 	gopathList := filepath.SplitList(build.Default.GOPATH)
-	// ignore the vendor folder
+	// Strip away the vendor folder
 	if i := strings.Index(path, "/vendor/"); i > 0 {
 		path = path[i+len("vendor/"):]
 	}

--- a/template.go
+++ b/template.go
@@ -114,7 +114,7 @@ func (loader *TemplateLoader) Refresh() (err *Error) {
 		templateMap: map[string]Template{}}
 
 	templateLog.Debug("Refresh: Refreshing templates from ", "path", loader.paths)
-	if err = loader.initializeEngines(runtimeLoader, GO_TEMPLATE); err != nil {
+	if err = loader.initializeEngines(runtimeLoader, Config.StringDefault("template.engines", GO_TEMPLATE)); err != nil {
 		return
 	}
 	for _, engine := range runtimeLoader.templatesAndEngineList {


### PR DESCRIPTION
Added args to be passed to action using the Controller.Redirect
Added namespace to resolved path
Renamed ServerHeader to Header (more backwards compatible)
Updated intercept module to sort intercepts by "depth" this ensures that the most embedded intercept gets called first
Added "appModule" to revel.Modules
Added additional logging in router.splitactionpath
Added setting template initialization engines to be read from template.engines