### PR TITLE
added Options method in Field

### DIFF
--- a/field.go
+++ b/field.go
@@ -13,17 +13,17 @@ import (
 type Field struct {
 	Name       string
 	Error      *ValidationError
-	viewArgs map[string]interface{}
+	viewArgs   map[string]interface{}
 	controller *Controller
 }
 
 func NewField(name string, viewArgs map[string]interface{}) *Field {
 	err, _ := viewArgs["errors"].(map[string]*ValidationError)[name]
-	controller,_ := viewArgs["_controller"].(*Controller)
+	controller, _ := viewArgs["_controller"].(*Controller)
 	return &Field{
 		Name:       name,
 		Error:      err,
-		viewArgs: viewArgs,
+		viewArgs:   viewArgs,
 		controller: controller,
 	}
 }
@@ -36,6 +36,15 @@ func (f *Field) ID() string {
 // Flash returns the flashed value of this Field.
 func (f *Field) Flash() string {
 	v, _ := f.viewArgs["flash"].(map[string]string)[f.Name]
+	return v
+}
+
+// Options returns the option list of this Field.
+func (f *Field) Options() []string {
+	if f.viewArgs["options"] == nil {
+		return nil
+	}
+	v, _ := f.viewArgs["options"].(map[string][]string)[f.Name]
 	return v
 }
 
@@ -84,15 +93,16 @@ func (f *Field) ErrorClass() string {
 // Get the short name and translate it
 func (f *Field) ShortName() string {
 	name := f.Name
-	if i:=strings.LastIndex(name,"."); i>0 {
+	if i := strings.LastIndex(name, "."); i > 0 {
 		name = name[i+1:]
 	}
 	return f.Translate(name)
 }
+
 // Translate the text
-func (f *Field) Translate(text string, args...interface{}) string {
-	if f.controller!=nil {
-		text = f.controller.Message(text,args...)
+func (f *Field) Translate(text string, args ...interface{}) string {
+	if f.controller != nil {
+		text = f.controller.Message(text, args...)
 	}
 	return text
 }


### PR DESCRIPTION
In order to created form field template, hope the option list can be included in Field structure and can be used in format as below
```html
 {{with $field := field "record.Status"}}
{{template "fieldTemplate/radio.html" $field}}
{{end}}
```

in radio.html template 
```html
{{.Name}}
{{range .Options }}
{{.}}
{{end}}
```
The option list can be set as the way set field value (which using flash). Options, use ViewArgs["options"]. 
```go
	c.ViewArgs["options"] = map[string][]string{
		"record.Status": map[string][]string{"Started","Ongoing", "Finished"},
	}
```
