### PR TITLE
 Fix JSON to struct deserialization

### DIFF
--- a/server_adapter_go.go
+++ b/server_adapter_go.go
@@ -418,5 +418,5 @@ func (g *GoWebSocket) MessageSendJSON(v interface{}) error {
 	return websocket.JSON.Send(g.Conn, v)
 }
 func (g *GoWebSocket) MessageReceiveJSON(v interface{}) error {
-	return websocket.Message.Receive(g.Conn, v)
+	return websocket.JSON.Receive(g.Conn, v)
 }


### PR DESCRIPTION
The Message codec can only handle strings and byte slices. Since the method is called JSON, let's call the JSON codec underneath.