### PR TITLE
Fix issue revel/cmd#113

### DIFF
--- a/results.go
+++ b/results.go
@@ -469,7 +469,13 @@ func getRedirectURL(item interface{}, args []interface{}) (string, error) {
 		}
 		module := ModuleFromPath(recvType.PkgPath(),true)
 		println("Returned ", module)
-		action := module.Namespace() + recvType.Name() + "." + method.Name
+		var moduleNamespace string
+		if module != nil {
+			moduleNamespace = module.Namespace()
+		} else {
+			moduleNamespace = recvType.Name()
+		}
+		action := moduleNamespace + recvType.Name() + "." + method.Name
 		// Fetch the action path to get the defaults
 		pathData, found := splitActionPath(nil, action, true)
 		if !found {

--- a/results.go
+++ b/results.go
@@ -156,8 +156,8 @@ func (r *RenderTemplateResult) Apply(req *Request, resp *Response) {
 	// error pages distorted by HTML already written)
 	if chunked && !DevMode {
 		resp.WriteHeader(http.StatusOK, "text/html; charset=utf-8")
-		if err := r.renderOutput(out); err !=nil {
-			r.renderError(err,req,resp)
+		if err := r.renderOutput(out); err != nil {
+			r.renderError(err, req, resp)
 		}
 		return
 	}
@@ -167,8 +167,8 @@ func (r *RenderTemplateResult) Apply(req *Request, resp *Response) {
 	// Otherwise, template render errors may result in unpredictable HTML (and
 	// would carry a 200 status code)
 	b, err := r.ToBytes()
-	if err!=nil {
-		r.renderError(err,req,resp)
+	if err != nil {
+		r.renderError(err, req, resp)
 		return
 	}
 
@@ -182,7 +182,7 @@ func (r *RenderTemplateResult) Apply(req *Request, resp *Response) {
 }
 
 // Return a byte array and or an error object if the template failed to render
-func (r *RenderTemplateResult) ToBytes() (b *bytes.Buffer,err error) {
+func (r *RenderTemplateResult) ToBytes() (b *bytes.Buffer, err error) {
 	defer func() {
 		if rerr := recover(); rerr != nil {
 			resultsLog.Error("ApplyBytes: panic recovery", "recover-error", rerr)
@@ -190,7 +190,7 @@ func (r *RenderTemplateResult) ToBytes() (b *bytes.Buffer,err error) {
 		}
 	}()
 	b = &bytes.Buffer{}
-	if err = r.renderOutput(b); err==nil {
+	if err = r.renderOutput(b); err == nil {
 		if Config.BoolDefault("results.trim.html", false) {
 			b = r.compressHtml(b)
 		}
@@ -259,7 +259,7 @@ func (r *RenderTemplateResult) compressHtml(b *bytes.Buffer) (b2 *bytes.Buffer) 
 }
 
 // Render the error in the response
-func (r *RenderTemplateResult) renderError(err error,req *Request, resp *Response) {
+func (r *RenderTemplateResult) renderError(err error, req *Request, resp *Response) {
 	var templateContent []string
 	templateName, line, description := ParseTemplateError(err)
 	if templateName == "" {
@@ -431,7 +431,7 @@ func (r *RedirectToURLResult) Apply(req *Request, resp *Response) {
 }
 
 type RedirectToActionResult struct {
-	val interface{}
+	val  interface{}
 	args []interface{}
 }
 
@@ -467,13 +467,11 @@ func getRedirectURL(item interface{}, args []interface{}) (string, error) {
 		if recvType.Kind() == reflect.Ptr {
 			recvType = recvType.Elem()
 		}
-		module := ModuleFromPath(recvType.PkgPath(),true)
+		module := ModuleFromPath(recvType.PkgPath(), true)
 		println("Returned ", module)
 		var moduleNamespace string
 		if module != nil {
 			moduleNamespace = module.Namespace()
-		} else {
-			moduleNamespace = recvType.Name()
 		}
 		action := moduleNamespace + recvType.Name() + "." + method.Name
 		// Fetch the action path to get the defaults
@@ -492,7 +490,6 @@ func getRedirectURL(item interface{}, args []interface{}) (string, error) {
 		for i, argValue := range args {
 			Unbind(argsByName, methodType.Args[i+fixedParams].Name, argValue)
 		}
-
 
 		actionDef := MainRouter.Reverse(action, argsByName)
 		if actionDef == nil {


### PR DESCRIPTION
In some cases (especially during a redirect), module on line 470 returned from `ModuleFromPath()` returned `nil`, causing the application to crash after using `module.Namespace()`.

This issue is addressed here revel/cmd#113.

Commit notzippy@75b7d91 introduced this bug.