### PR TITLE
add WebDav and Cache Method (PURGE)

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -225,7 +225,7 @@ func testGetMulti(t *testing.T, newCache cacheFactory) {
 	var keys []string
 	for key, value := range m {
 		keys = append(keys, key)
-		if err := cache.Set(key, value, time.Second*10); err != nil {
+		if err := cache.Set(key, value, time.Second*30); err != nil {
 			t.Errorf("Error setting a value: %s", err)
 		}
 	}

--- a/router.go
+++ b/router.go
@@ -14,9 +14,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/revel/pathtree"
 	"os"
 	"sync"
+
+	"github.com/revel/pathtree"
 )
 
 const (
@@ -298,7 +299,7 @@ func splitActionPath(actionPathData *ActionPathData, actionPath string, useCache
 		controllerNamespace, controllerName, methodName, action string
 		foundModuleSource                                       *Module
 		typeOfController                                        *ControllerType
-		log = routerLog.New("actionPath",actionPath)
+		log                                                     = routerLog.New("actionPath", actionPath)
 	)
 	actionSplit := strings.Split(actionPath, ".")
 	if actionPathData != nil {
@@ -309,8 +310,8 @@ func splitActionPath(actionPathData *ActionPathData, actionPath string, useCache
 		if i := strings.Index(methodName, "("); i > 0 {
 			methodName = methodName[:i]
 		}
-		log = log.New("controller", controllerName, "method",methodName)
-		log.Debug("splitActionPath: Check for namespace",)
+		log = log.New("controller", controllerName, "method", methodName)
+		log.Debug("splitActionPath: Check for namespace")
 		if i := strings.Index(controllerName, namespaceSeperator); i > -1 {
 			controllerNamespace = controllerName[:i+1]
 			if moduleSource, found := ModuleByName(controllerNamespace[:len(controllerNamespace)-1]); found {
@@ -415,9 +416,9 @@ func splitActionPath(actionPathData *ActionPathData, actionPath string, useCache
 		}
 		pathData.Key = actionPath
 		actionPathCacheMap[actionPath] = pathData
-		if !strings.Contains(actionPath,namespaceSeperator) && pathData.TypeOfController!=nil {
-			actionPathCacheMap[strings.ToLower(pathData.TypeOfController.Namespace) + actionPath] = pathData
-			log.Debugf("splitActionPath: Split Storing recognized action path %s for route  %#v ", strings.ToLower(pathData.TypeOfController.Namespace) + actionPath, actionPathData.Route)
+		if !strings.Contains(actionPath, namespaceSeperator) && pathData.TypeOfController != nil {
+			actionPathCacheMap[strings.ToLower(pathData.TypeOfController.Namespace)+actionPath] = pathData
+			log.Debugf("splitActionPath: Split Storing recognized action path %s for route  %#v ", strings.ToLower(pathData.TypeOfController.Namespace)+actionPath, actionPathData.Route)
 		}
 	}
 	return
@@ -580,7 +581,7 @@ func getModuleRoutes(moduleName, joinedPath string, validate bool) (routes []*Ro
 // 5: action
 // 6: fixedargs
 var routePattern = regexp.MustCompile(
-	"(?i)^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD|WS|\\*)" +
+	"(?i)^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD|WS|PROPFIND|MKCOL|COPY|MOVE|PROPPATCH|LOCK|UNLOCK|TRACE|PURGE|\\*)" +
 		"[(]?([^)]*)(\\))?[ \t]+" +
 		"(.*/[^ \t]*)[ \t]+([^ \t(]+)" +
 		`\(?([^)]*)\)?[ \t]*$`)
@@ -613,14 +614,14 @@ func (a *ActionDefinition) String() string {
 }
 
 func (router *Router) Reverse(action string, argValues map[string]string) (ad *ActionDefinition) {
-	log := routerLog.New("action",action)
+	log := routerLog.New("action", action)
 	pathData, found := splitActionPath(nil, action, true)
 	if !found {
 		routerLog.Error("splitActionPath: Failed to find reverse route", "action", action, "arguments", argValues)
 		return nil
 	}
 
-	log.Debug("Checking for route","pathdataRoute",pathData.Route)
+	log.Debug("Checking for route", "pathdataRoute", pathData.Route)
 	if pathData.Route == nil {
 		var possibleRoute *Route
 		// If the route is nil then we need to go through the routes to find the first matching route

--- a/router_test.go
+++ b/router_test.go
@@ -115,12 +115,21 @@ func TestComputeRoute(t *testing.T) {
 
 const TestRoutes = `
 # This is a comment
-GET   /                          Application.Index
-GET   /test/                     Application.Index("Test", "Test2")
-GET   /app/:id/                  Application.Show
-GET   /app-wild/*id/             Application.WildShow
-POST  /app/:id                   Application.Save
-PATCH /app/:id/                  Application.Update
+GET   		/                   Application.Index
+GET   		/test/              Application.Index("Test", "Test2")
+GET   		/app/:id/           Application.Show
+GET   		/app-wild/*id/		Application.WildShow
+POST  		/app/:id            Application.Save
+PATCH 		/app/:id/           Application.Update
+PROPFIND	/app/:id			Application.WebDevMethodPropFind
+MKCOL		/app/:id			Application.WebDevMethodMkCol
+COPY		/app/:id			Application.WebDevMethodCopy
+MOVE		/app/:id			Application.WebDevMethodMove
+PROPPATCH	/app/:id			Application.WebDevMethodPropPatch
+LOCK		/app/:id			Application.WebDevMethodLock
+UNLOCK		/app/:id			Application.WebDevMethodUnLock
+TRACE		/app/:id			Application.WebDevMethodTrace
+PURGE		/app/:id			Application.CacheMethodPurge
 GET   /javascript/:filepath      App\Static.Serve("public/js")
 GET   /public/*filepath          Static.Serve("public")
 *     /:controller/:action       :controller.:action
@@ -255,6 +264,105 @@ var routeMatchTestCases = map[*http.Request]*RouteMatch{
 		FixedParams:    []string{},
 		Params:         map[string][]string{"id": {"123"}},
 	},
+
+	&http.Request{
+		Method: "PATCH",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "Update",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
+
+	&http.Request{
+		Method: "PROPFIND",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "WebDevMethodPropFind",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
+
+	&http.Request{
+		Method: "MKCOL",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "WebDevMethodMkCol",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
+
+	&http.Request{
+		Method: "COPY",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "WebDevMethodCopy",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
+
+	&http.Request{
+		Method: "MOVE",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "WebDevMethodMove",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
+
+	&http.Request{
+		Method: "PROPPATCH",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "WebDevMethodPropPatch",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
+	&http.Request{
+		Method: "LOCK",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "WebDevMethodLock",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
+
+	&http.Request{
+		Method: "UNLOCK",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "WebDevMethodUnLock",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
+
+	&http.Request{
+		Method: "TRACE",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "WebDevMethodTrace",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
+
+	&http.Request{
+		Method: "PURGE",
+		URL:    &url.URL{Path: "/app/123"},
+	}: {
+		ControllerName: "application",
+		MethodName:     "CacheMethodPurge",
+		FixedParams:    []string{},
+		Params:         map[string][]string{"id": {"123"}},
+	},
 }
 
 func TestRouteMatches(t *testing.T) {
@@ -350,6 +458,88 @@ var reverseRoutingTestCases = map[*ReverseRouteArgs]*ActionDefinition{
 		Method: "GET",
 		Star:   false,
 		Action: "Application.WildShow",
+	},
+
+	&ReverseRouteArgs{
+		action: "Application.WebDevMethodPropFind",
+		args:   map[string]string{"id": "123"},
+	}: {
+		URL:    "/app/123",
+		Method: "PROPFIND",
+		Star:   false,
+		Action: "Application.WebDevMethodPropFind",
+	},
+	&ReverseRouteArgs{
+		action: "Application.WebDevMethodMkCol",
+		args:   map[string]string{"id": "123"},
+	}: {
+		URL:    "/app/123",
+		Method: "MKCOL",
+		Star:   false,
+		Action: "Application.WebDevMethodMkCol",
+	},
+	&ReverseRouteArgs{
+		action: "Application.WebDevMethodCopy",
+		args:   map[string]string{"id": "123"},
+	}: {
+		URL:    "/app/123",
+		Method: "COPY",
+		Star:   false,
+		Action: "Application.WebDevMethodCopy",
+	},
+	&ReverseRouteArgs{
+		action: "Application.WebDevMethodMove",
+		args:   map[string]string{"id": "123"},
+	}: {
+		URL:    "/app/123",
+		Method: "MOVE",
+		Star:   false,
+		Action: "Application.WebDevMethodMove",
+	},
+	&ReverseRouteArgs{
+		action: "Application.WebDevMethodPropPatch",
+		args:   map[string]string{"id": "123"},
+	}: {
+		URL:    "/app/123",
+		Method: "PROPPATCH",
+		Star:   false,
+		Action: "Application.WebDevMethodPropPatch",
+	},
+	&ReverseRouteArgs{
+		action: "Application.WebDevMethodLock",
+		args:   map[string]string{"id": "123"},
+	}: {
+		URL:    "/app/123",
+		Method: "LOCK",
+		Star:   false,
+		Action: "Application.WebDevMethodLock",
+	},
+	&ReverseRouteArgs{
+		action: "Application.WebDevMethodUnLock",
+		args:   map[string]string{"id": "123"},
+	}: {
+		URL:    "/app/123",
+		Method: "UNLOCK",
+		Star:   false,
+		Action: "Application.WebDevMethodUnLock",
+	},
+	&ReverseRouteArgs{
+		action: "Application.WebDevMethodTrace",
+		args:   map[string]string{"id": "123"},
+	}: {
+		URL:    "/app/123",
+		Method: "TRACE",
+		Star:   false,
+		Action: "Application.WebDevMethodTrace",
+	},
+	&ReverseRouteArgs{
+		action: "Application.CacheMethodPurge",
+		args:   map[string]string{"id": "123"},
+	}: {
+		URL:    "/app/123",
+		Method: "PURGE",
+		Star:   false,
+		Action: "Application.CacheMethodPurge",
 	},
 }
 


### PR DESCRIPTION
I Added Webdav and Cache Methods to router.go(routePattern)

*Currently, Revel only supports method are below*
```go
GETPOST|PUT|DELETE|PATCH|OPTIONS|HEAD|WS
```
*API server need to additional methods, The following is new methods*
```
PROPFIND	
MKCOL		
COPY		
MOVE		
PROPPATCH	
LOCK		
UNLOCK		
TRACE		
PURGE		
```
Cheers.