### PR TITLE
Feature/better required validator

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -30,17 +30,17 @@ func ValidRequired() Required {
 
 func (r Required) IsSatisfied(obj interface{}) bool {
 	if obj == nil {
-		return true
+		return false
 	}
 	switch v := reflect.ValueOf(obj); v.Kind() {
 	case reflect.Array, reflect.Slice, reflect.Map, reflect.String, reflect.Chan:
 		if v.Len() == 0 {
-			return true
+			return false
 		}
 	case reflect.Ptr:
-		return isEmpty(reflect.Indirect(v).Interface())
+		return r.IsSatisfied(reflect.Indirect(v).Interface())
 	}
-	return reflect.DeepEqual(reflect.Zero(reflect.TypeOf(obj)).Interface(), obj)
+	return !reflect.DeepEqual(obj, reflect.Zero(reflect.TypeOf(obj)).Interface())
 }
 
 func (r Required) DefaultMessage() string {

--- a/validators.go
+++ b/validators.go
@@ -30,27 +30,7 @@ func ValidRequired() Required {
 }
 
 func (r Required) IsSatisfied(obj interface{}) bool {
-	if obj == nil {
-		return false
-	}
-
-	if str, ok := obj.(string); ok {
-		return utf8.RuneCountInString(str) > 0
-	}
-	if b, ok := obj.(bool); ok {
-		return b
-	}
-	if i, ok := obj.(int); ok {
-		return i != 0
-	}
-	if t, ok := obj.(time.Time); ok {
-		return !t.IsZero()
-	}
-	v := reflect.ValueOf(obj)
-	if v.Kind() == reflect.Slice {
-		return v.Len() > 0
-	}
-	return true
+	return obj != nil && obj != reflect.Zero(reflect.TypeOf(obj)).Interface();
 }
 
 func (r Required) DefaultMessage() string {

--- a/validators.go
+++ b/validators.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 	"unicode/utf8"
 )
 

--- a/validators.go
+++ b/validators.go
@@ -34,7 +34,7 @@ func (r Required) IsSatisfied(obj interface{}) bool {
 }
 
 func (r Required) DefaultMessage() string {
-	return "Required"
+	return fmt.Sprintln("Required")
 }
 
 type Min struct {

--- a/validators.go
+++ b/validators.go
@@ -29,7 +29,18 @@ func ValidRequired() Required {
 }
 
 func (r Required) IsSatisfied(obj interface{}) bool {
-	return obj != nil && !reflect.DeepEqual(obj, reflect.Zero(reflect.TypeOf(obj)).Interface());
+	if obj == nil {
+		return true
+	}
+	switch v := reflect.ValueOf(obj); v.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Map, reflect.String, reflect.Chan:
+		if v.Len() == 0 {
+			return true
+		}
+	case reflect.Ptr:
+		return isEmpty(reflect.Indirect(v).Interface())
+	}
+	return reflect.DeepEqual(reflect.Zero(reflect.TypeOf(obj)).Interface(), obj)
 }
 
 func (r Required) DefaultMessage() string {

--- a/validators.go
+++ b/validators.go
@@ -29,7 +29,7 @@ func ValidRequired() Required {
 }
 
 func (r Required) IsSatisfied(obj interface{}) bool {
-	return obj != nil && obj != reflect.Zero(reflect.TypeOf(obj)).Interface();
+	return obj != nil && !reflect.DeepEqual(obj, reflect.Zero(reflect.TypeOf(obj)).Interface());
 }
 
 func (r Required) DefaultMessage() string {

--- a/validators_test.go
+++ b/validators_test.go
@@ -39,7 +39,6 @@ func performTests(validator revel.Validator, tests []Expect, t *testing.T) {
 }
 
 func TestRequired(t *testing.T) {
-
 	tests := []Expect{
 		{nil, false, "nil data"},
 		{"Testing", true, "non-empty string"},

--- a/validators_test.go
+++ b/validators_test.go
@@ -6,6 +6,7 @@ package revel_test
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"regexp"
 	"strings"
@@ -51,6 +52,7 @@ func TestRequired(t *testing.T) {
 		{time.Now(), true, "current time"},
 		{time.Time{}, false, "a zero time"},
 		{func() {}, true, "other non-nil data types"},
+		{net.IP(""), false, "empty IP address"},
 	}
 
 	// testing both the struct and the helper method


### PR DESCRIPTION
I thought we should allow more types to be validated against `Required` validator. The easiest way to do it is using `reflect`. Now we will be able to validate bit-specific `int`'s, `uint`'s, `float`'s, `struct`'s, etc.

Additionally I standardised default message to be consistent with other validators (having line break at the end).