### PR TITLE
Added functional logger.

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,48 +13,82 @@ type (
 	// The Multilogger reduces the number of exposed defined logging variables,
 	// and allows the output to be easily refined
 	MultiLogger interface {
-		//log15.Logger
-		//// New returns a new Logger that has this logger's context plus the given context
+		// New returns a new Logger that has this logger's context plus the given context
 		New(ctx ...interface{}) MultiLogger
-		//
-		//// SetHandler updates the logger to write records to the specified handler.
+
+		// SetHandler updates the logger to write records to the specified handler.
 		SetHandler(h LogHandler)
+		// Set the stack depth for the logger
 		SetStackDepth(int) MultiLogger
-		//
-		//// Log a message at the given level with context key/value pairs
+
+		// Log a message at the given level with context key/value pairs
 		Debug(msg string, ctx ...interface{})
+
+		// Log a message at the given level formatting message with the parameters
 		Debugf(msg string, params ...interface{})
+
+		// Log a message at the given level with context key/value pairs
 		Info(msg string, ctx ...interface{})
+
+		// Log a message at the given level formatting message with the parameters
 		Infof(msg string, params ...interface{})
+
+		// Log a message at the given level with context key/value pairs
 		Warn(msg string, ctx ...interface{})
+
+		// Log a message at the given level formatting message with the parameters
 		Warnf(msg string, params ...interface{})
+
+		// Log a message at the given level with context key/value pairs
 		Error(msg string, ctx ...interface{})
+
+		// Log a message at the given level formatting message with the parameters
 		Errorf(msg string, params ...interface{})
+
+		// Log a message at the given level with context key/value pairs
 		Crit(msg string, ctx ...interface{})
+
+		// Log a message at the given level formatting message with the parameters
 		Critf(msg string, params ...interface{})
 
-		//// Logs a message as an Crit and exits
+		// Log a message at the given level with context key/value pairs and exits
 		Fatal(msg string, ctx ...interface{})
+
+		// Log a message at the given level formatting message with the parameters and exits
 		Fatalf(msg string, params ...interface{})
-		//// Logs a message as an Crit and panics
+
+		// Log a message at the given level with context key/value pairs and panics
 		Panic(msg string, ctx ...interface{})
+
+		// Log a message at the given level formatting message with the parameters and panics
 		Panicf(msg string, params ...interface{})
 	}
+
+	// The log handler interface
 	LogHandler interface {
 		log15.Handler
 	}
+
+	// The log stack handler interface
 	LogStackHandler interface {
 		LogHandler
 		GetStack() int
 	}
+
+	// The log handler interface which has child logs
 	ParentLogHandler interface {
 		SetChild(handler LogHandler) LogHandler
 	}
+
+	// The log format interface
 	LogFormat interface {
 		log15.Format
 	}
 
+	// The log level type
 	LogLevel    log15.Lvl
+
+	// This type implements the MultiLogger
 	RevelLogger struct {
 		log15.Logger
 	}
@@ -70,10 +104,19 @@ type (
 )
 
 const (
+	// Debug level
 	LvlDebug = LogLevel(log15.LvlDebug)
+
+	// Info level
 	LvlInfo  = LogLevel(log15.LvlInfo)
+
+	// Warn level
 	LvlWarn  = LogLevel(log15.LvlWarn)
+
+	// Error level
 	LvlError = LogLevel(log15.LvlError)
+
+	// Critical level
 	LvlCrit  = LogLevel(log15.LvlCrit)
 )
 
@@ -117,33 +160,48 @@ func SetDefaultLog(fromLog MultiLogger) {
 	log.SetFlags(0)
 }
 
+// Print a formatted debug message
 func (rl *RevelLogger) Debugf(msg string, param ...interface{}) {
 	rl.Debug(fmt.Sprintf(msg, param...))
 }
+
+// Print a formatted info message
 func (rl *RevelLogger) Infof(msg string, param ...interface{}) {
 	rl.Info(fmt.Sprintf(msg, param...))
 }
+
+// Print a formatted warn message
 func (rl *RevelLogger) Warnf(msg string, param ...interface{}) {
 	rl.Warn(fmt.Sprintf(msg, param...))
 }
+
+// Print a formatted error message
 func (rl *RevelLogger) Errorf(msg string, param ...interface{}) {
 	rl.Error(fmt.Sprintf(msg, param...))
 }
+
+// Print a formatted critical message
 func (rl *RevelLogger) Critf(msg string, param ...interface{}) {
 	rl.Crit(fmt.Sprintf(msg, param...))
 }
+
+// Print a formatted fatal message
 func (rl *RevelLogger) Fatalf(msg string, param ...interface{}) {
 	rl.Fatal(fmt.Sprintf(msg, param...))
 }
+
+// Print a formatted panic message
 func (rl *RevelLogger) Panicf(msg string, param ...interface{}) {
 	rl.Panic(fmt.Sprintf(msg, param...))
 }
 
+// Print a critical message and call os.Exit(1)
 func (rl *RevelLogger) Fatal(msg string, ctx ...interface{}) {
 	rl.Crit(msg, ctx...)
 	os.Exit(1)
 }
 
+// Print a critical message and panic
 func (rl *RevelLogger) Panic(msg string, ctx ...interface{}) {
 	rl.Crit(msg, ctx...)
 	panic(msg)
@@ -173,14 +231,17 @@ func (rl *RevelLogger) SetHandler(h LogHandler) {
 	rl.Logger.SetHandler(h)
 }
 
+// Implements the ParentLogHandler
 type parentLogHandler struct {
 	setChild func(handler LogHandler) LogHandler
 }
 
+// Create a new parent log handler
 func NewParentLogHandler(callBack func(child LogHandler) LogHandler) ParentLogHandler {
 	return &parentLogHandler{callBack}
 }
 
+// Sets the child of the log handler
 func (p *parentLogHandler) SetChild(child LogHandler) LogHandler {
 	return p.setChild(child)
 }
@@ -203,18 +264,24 @@ func (l *LogOptions) SetExtendedOptions(options ...interface{}) {
 		l.ExtendedOptions[options[x].(string)] = options[x+1]
 	}
 }
+
+// Gets a string option with default
 func (l *LogOptions) GetStringDefault(option, value string) string {
 	if v, found := l.ExtendedOptions[option]; found {
 		return v.(string)
 	}
 	return value
 }
+
+// Gets an int option with default
 func (l *LogOptions) GetIntDefault(option string, value int) int {
 	if v, found := l.ExtendedOptions[option]; found {
 		return v.(int)
 	}
 	return value
 }
+
+// Gets a boolean option with default
 func (l *LogOptions) GetBoolDefault(option string, value bool) bool {
 	if v, found := l.ExtendedOptions[option]; found {
 		return v.(bool)

--- a/logger/utils.go
+++ b/logger/utils.go
@@ -1,13 +1,15 @@
 package logger
 
 import (
-	"gopkg.in/stack.v0"
+	"fmt"
 	"github.com/revel/config"
 	"github.com/revel/log15"
+	"gopkg.in/stack.v0"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Utility package to make existing logging backwards compatible
@@ -20,6 +22,7 @@ var (
 	}
 )
 
+// Returns the logger for the name
 func GetLogger(name string, logger MultiLogger) (l *log.Logger) {
 	switch name {
 	case "trace": // TODO trace is deprecated, replaced by debug
@@ -71,52 +74,54 @@ func initAllLog(c *CompositeMultiHandler, basePath string, config *config.Contex
 	}
 }
 
+// Used by the initFilterLog to handle the filters
+var logFilterList = []struct {
+	LogPrefix, LogSuffix string
+	parentHandler        func(map[string]interface{}) ParentLogHandler
+}{{
+	"log.", ".filter",
+	func(keyMap map[string]interface{}) ParentLogHandler {
+		return NewParentLogHandler(func(child LogHandler) LogHandler {
+			return MatchMapHandler(keyMap, child)
+		})
+
+	},
+}, {
+	"log.", ".nfilter",
+	func(keyMap map[string]interface{}) ParentLogHandler {
+		return NewParentLogHandler(func(child LogHandler) LogHandler {
+			return NotMatchMapHandler(keyMap, child)
+		})
+	},
+}}
+
 // Init the filter options
 // log.all.filter ....
 // log.error.filter ....
 func initFilterLog(c *CompositeMultiHandler, basePath string, config *config.Context) {
-	if config != nil {
-		// The commands to use
-		logFilterList := []struct {
-			LogPrefix, LogSuffix string
-			parentHandler        func(map[string]interface{}) ParentLogHandler
-		}{{
-			"log.", ".filter",
-			func(keyMap map[string]interface{}) ParentLogHandler {
-				return NewParentLogHandler(func(child LogHandler) LogHandler {
-					return MatchMapHandler(keyMap, child)
-				})
+	if config == nil {
+		return
+	}
 
-			},
-		}, {
-			"log.", ".nfilter",
-			func(keyMap map[string]interface{}) ParentLogHandler {
-				return NewParentLogHandler(func(child LogHandler) LogHandler {
-					return NotMatchMapHandler(keyMap, child)
-				})
-			},
-		}}
+	for _, logFilter := range logFilterList {
+		// Init for all filters
+		for _, name := range []string{"all", "debug", "info", "warn", "error", "crit",
+			"trace", // TODO trace is deprecated
+		} {
+			optionList := config.Options(logFilter.LogPrefix + name + logFilter.LogSuffix)
+			for _, option := range optionList {
+				splitOptions := strings.Split(option, ".")
+				keyMap := map[string]interface{}{}
+				for x := 3; x < len(splitOptions); x += 2 {
+					keyMap[splitOptions[x]] = splitOptions[x+1]
+				}
+				phandler := logFilter.parentHandler(keyMap)
+				log.Printf("Adding key map handler %s %s output %s", option, name, config.StringDefault(option, ""))
 
-		for _, logFilter := range logFilterList {
-			// Init for all filters
-			for _, name := range []string{"all", "debug", "info", "warn", "error", "crit",
-				"trace", // TODO trace is deprecated
-			} {
-				optionList := config.Options(logFilter.LogPrefix + name + logFilter.LogSuffix)
-				for _, option := range optionList {
-					splitOptions := strings.Split(option, ".")
-					keyMap := map[string]interface{}{}
-					for x := 3; x < len(splitOptions); x += 2 {
-						keyMap[splitOptions[x]] = splitOptions[x+1]
-					}
-					phandler := logFilter.parentHandler(keyMap)
-					log.Printf("Adding key map handler %s %s output %s", option, name, config.StringDefault(option, ""))
-
-					if name == "all" {
-						initHandlerFor(c, config.StringDefault(option, ""), basePath, NewLogOptions(config, false, phandler))
-					} else {
-						initHandlerFor(c, config.StringDefault(option, ""), basePath, NewLogOptions(config, false, phandler, toLevel[name]))
-					}
+				if name == "all" {
+					initHandlerFor(c, config.StringDefault(option, ""), basePath, NewLogOptions(config, false, phandler))
+				} else {
+					initHandlerFor(c, config.StringDefault(option, ""), basePath, NewLogOptions(config, false, phandler, toLevel[name]))
 				}
 			}
 		}
@@ -221,8 +226,10 @@ type loggerRewrite struct {
 	hideDeprecated bool
 }
 
+// The message indicating that a logger is using a deprecated log mechanism
 var log_deprecated = []byte("* LOG DEPRECATED * ")
 
+// Implements the Write of the logger
 func (lr loggerRewrite) Write(p []byte) (n int, err error) {
 	if !lr.hideDeprecated {
 		p = append(log_deprecated, p...)
@@ -254,4 +261,61 @@ func (lr loggerRewrite) Write(p []byte) (n int, err error) {
 // `controller.Log.Critc("This should not occur","stack",revel.NewCallStack())`
 func NewCallStack() interface{} {
 	return stack.Trace()
+}
+
+// Currently the only requirement for the callstack is to support the Formatter method
+// which stack.Call does
+type CallStack interface {
+	fmt.Formatter
+
+}
+// Call to define a handler function for the logs
+func HandlerFunc(log func(message string, time time.Time, level LogLevel, call CallStack, context ContextMap) error) LogHandler {
+	return callHandler(log)
+}
+
+// The function wrapper to implement the callback
+type callHandler func(message string, time time.Time, level LogLevel, call CallStack, context ContextMap) error
+
+// Log implementation, reads the record and extracts the details from the log record
+// Hiding the implementation.
+func (c callHandler) Log(log *log15.Record) error {
+	ctx := log.Ctx
+	var ctxMap ContextMap
+	if len(ctx) > 0 {
+		ctxMap = make(ContextMap, len(ctx)/2)
+
+		for i := 0; i < len(ctx); i += 2 {
+			v := ctx[i]
+			key, ok := v.(string)
+			if !ok {
+				key = fmt.Sprintf("LOGGER_INVALID_KEY %v", v)
+			}
+			var value interface{}
+			if len(ctx) > i+1 {
+				value = ctx[i+1]
+			} else {
+				value = "LOGGER_VALUE_MISSING"
+			}
+			ctxMap[key] = value
+		}
+	}
+
+	return c(log.Msg, log.Time, LogLevel(log.Lvl), CallStack(log.Call), ctxMap)
+}
+
+// Internally used contextMap, allows conversion of map to map[string]string
+type ContextMap map[string]interface{}
+
+// Convert the context map to be string only values, any non string values are ignored
+func (m ContextMap) StringMap() (newMap map[string]string) {
+	if m != nil {
+		newMap = map[string]string{}
+		for key, value := range m {
+			if svalue, isstring := value.(string); isstring {
+				newMap[key] = svalue
+			}
+		}
+	}
+	return
 }


### PR DESCRIPTION
Added function logger

In the following sample implementation all messages that were routed to the stdout logger will now be sent to the `foo` function and printed
```
	logger.LogFunctionMap["stdout"] =
		func(c *logger.CompositeMultiHandler, options *logger.LogOptions) {
			foo := func (message string, time time.Time, level logger.LogLevel, call logger.CallStack, context logger.ContextMap) (error) {
				println("yup ********", message, fmt.Sprintf("%v",context))
				return nil
			}

			c.SetHandlers(logger.HandlerFunc(foo),options)
		}

```