### PR TITLE
Fix import to point to the fsnotify/fsnotify.v1.

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 )
 
 // Listener is an interface for receivers of filesystem events.


### PR DESCRIPTION
@https://github.com/go-fsnotify/fsnotify/issues/1
@https://github.com/revel/revel/issues/1323