### PR TITLE
Updates fsnotify import path due to import path vulnerability

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 )
 
 // Listener is an interface for receivers of filesystem events.


### PR DESCRIPTION
Due to the vulnerability discussed in  https://github.com/go-fsnotify/fsnotify/issues/1, this patch corrects the import path for fsnotify.