### PR TITLE
fix template_engine.go's DEBUG bug of command "revel version";

### DIFF
--- a/template_engine.go
+++ b/template_engine.go
@@ -42,7 +42,7 @@ func RegisterTemplateLoader(key string, loader func(loader *TemplateLoader) (Tem
 	if _, found := templateLoaderMap[key]; found {
 		err = fmt.Errorf("Template loader %s already exists", key)
 	}
-	templateLog.Debug("Registered template engine loaded", key)
+	templateLog.Debug("Registered template engine loaded", "name", key)
 	templateLoaderMap[key] = loader
 	return
 }


### PR DESCRIPTION
When I use command "revel version" to check the revel's version, I saw a bug there, and the below is the screenshot.
I have reviewed the code, and find in line 45 of "template_engine.go" have something wrong.
`templateLog.Debug("Registered template engine loaded", key)`
according to the log15, we missed one parameter. and I change it to
`templateLog.Debug("Registered template engine loaded", "name", key)`

Please check is it right, thanks!

![image](https://user-images.githubusercontent.com/5534122/44333088-64f06980-a4a0-11e8-8169-31d1e9470237.png)
