### PR TITLE
Correct Revel installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Enter Go's path (format varies based on OS):
 
 Install Revel:
 
+	go get -u github.com/revel/revel
+
+Install the Revel command line tool:
+
 	go get -u github.com/revel/cmd/revel
 
 Create & Run your app:


### PR DESCRIPTION
Because the Revel command does not include the revel package anymore it's not sufficient to do 
`go get -u github.com/revel/cmd/revel`. I just ran into this problem and thought the Readme might need a little update here.