### PR TITLE
Shutdown update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ install:
   - git clone -b $REVEL_BRANCH git://github.com/revel/config ../config/
   - git clone -b $REVEL_BRANCH git://github.com/revel/cron ../cron/
   - git clone -b $REVEL_BRANCH git://github.com/revel/examples ../examples/
-  - go get -v github.com/revel/revel/...
-  - go get -v github.com/revel/cmd/revel
+  - go get -t -v github.com/revel/revel/...
+  - go get -t -v github.com/revel/cmd/revel
 
 script:
   - go test -v github.com/revel/revel/...

--- a/event.go
+++ b/event.go
@@ -24,6 +24,10 @@ const (
 	ENGINE_BEFORE_INITIALIZED
 	// Event type before server engine is started, receivers are active server engine and handlers added to AddInitEventHandler
 	ENGINE_STARTED
+
+	// Event raised when the engine is told to shutdown
+	ENGINE_SHUTDOWN_REQUEST
+
 	// Event type after server engine is stopped, receivers are active server engine and handlers added to AddInitEventHandler
 	ENGINE_SHUTDOWN
 
@@ -38,6 +42,7 @@ const (
 
 // Fires system events from revel
 func RaiseEvent(key Event, value interface{}) (response EventResponse) {
+	utilLog.Info("Raising event","len",len(initEventList))
 	for _, handler := range initEventList {
 		response |= handler(key, value)
 	}

--- a/fakeapp_test.go
+++ b/fakeapp_test.go
@@ -137,9 +137,6 @@ func registerControllers() {
 func startFakeBookingApp() {
 	Init("prod", "github.com/revel/revel/testdata", "")
 
-	// Disable logging.
-	GetRootLogHandler().Disable()
-
 	MainTemplateLoader = NewTemplateLoader([]string{ViewsPath, filepath.Join(RevelPath, "templates")})
 	if err := MainTemplateLoader.Refresh(); err != nil {
 		ERROR.Fatal(err)
@@ -148,6 +145,7 @@ func startFakeBookingApp() {
 	registerControllers()
 
 	InitServerEngine(9000, GO_NATIVE_SERVER_ENGINE)
-	initControllerStack()
-	runStartupHooks()
+	RaiseEvent(ENGINE_BEFORE_INITIALIZED, nil)
+	InitServer()
+	RaiseEvent(ENGINE_STARTED, nil)
 }

--- a/logger/composite_multihandler.go
+++ b/logger/composite_multihandler.go
@@ -1,0 +1,174 @@
+package logger
+
+import (
+	"github.com/mattn/go-colorable"
+	"gopkg.in/natefinch/lumberjack.v2"
+	"io"
+	"os"
+)
+
+type CompositeMultiHandler struct {
+	DebugHandler    LogHandler
+	InfoHandler     LogHandler
+	WarnHandler     LogHandler
+	ErrorHandler    LogHandler
+	CriticalHandler LogHandler
+}
+
+func NewCompositeMultiHandler() (*CompositeMultiHandler, LogHandler) {
+	cw := &CompositeMultiHandler{}
+	return cw, cw
+}
+func (h *CompositeMultiHandler) Log(r *Record) (err error) {
+
+	var handler LogHandler
+
+	switch r.Level {
+	case LvlInfo:
+		handler = h.InfoHandler
+	case LvlDebug:
+		handler = h.DebugHandler
+	case LvlWarn:
+		handler = h.WarnHandler
+	case LvlError:
+		handler = h.ErrorHandler
+	case LvlCrit:
+		handler = h.CriticalHandler
+	}
+
+	// Embed the caller function in the context
+	if handler != nil {
+		handler.Log(r)
+	}
+	return
+}
+
+func (h *CompositeMultiHandler) SetHandler(handler LogHandler, replace bool, level LogLevel) {
+	if handler == nil {
+		// Ignore empty handler
+		return
+	}
+	source := &h.DebugHandler
+	switch level {
+	case LvlDebug:
+		source = &h.DebugHandler
+	case LvlInfo:
+		source = &h.InfoHandler
+	case LvlWarn:
+		source = &h.WarnHandler
+	case LvlError:
+		source = &h.ErrorHandler
+	case LvlCrit:
+		source = &h.CriticalHandler
+	}
+
+	if !replace && *source != nil {
+		// If we are not replacing the source make sure that the level handler is applied first
+		if _, isLevel := (*source).(*LevelFilterHandler); !isLevel {
+			*source = LevelHandler(level, *source)
+		}
+		// If this already was a list add a new logger to it
+		if ll, found := (*source).(*ListLogHandler); found {
+			ll.Add(handler)
+		} else {
+			*source = NewListLogHandler(*source, handler)
+		}
+	} else {
+		*source = handler
+	}
+}
+
+// For the multi handler set the handler, using the LogOptions defined
+func (h *CompositeMultiHandler) SetHandlers(handler LogHandler, options *LogOptions) {
+	if len(options.Levels) == 0 {
+		options.Levels = LvlAllList
+	}
+
+	// Set all levels
+	for _, lvl := range options.Levels {
+		h.SetHandler(handler, options.ReplaceExistingHandler, lvl)
+	}
+
+}
+func (h *CompositeMultiHandler) SetJson(writer io.Writer, options *LogOptions) {
+	handler := CallerFileHandler(StreamHandler(writer, JsonFormatEx(
+		options.GetBoolDefault("pretty", false),
+		options.GetBoolDefault("lineSeparated", true),
+	)))
+	if options.HandlerWrap != nil {
+		handler = options.HandlerWrap.SetChild(handler)
+	}
+	h.SetHandlers(handler, options)
+}
+
+// Use built in rolling function
+func (h *CompositeMultiHandler) SetJsonFile(filePath string, options *LogOptions) {
+	writer := &lumberjack.Logger{
+		Filename:   filePath,
+		MaxSize:    options.GetIntDefault("maxSizeMB", 1024), // megabytes
+		MaxAge:     options.GetIntDefault("maxAgeDays", 7),   //days
+		MaxBackups: options.GetIntDefault("maxBackups", 7),
+		Compress:   options.GetBoolDefault("compress", true),
+	}
+	h.SetJson(writer, options)
+}
+
+func (h *CompositeMultiHandler) SetTerminal(writer io.Writer, options *LogOptions) {
+	streamHandler := StreamHandler(
+		writer,
+		TerminalFormatHandler(
+			options.GetBoolDefault("noColor", false),
+			options.GetBoolDefault("smallDate", true)))
+
+	if os.Stdout == writer {
+		streamHandler = StreamHandler(
+			colorable.NewColorableStdout(),
+			TerminalFormatHandler(
+				options.GetBoolDefault("noColor", false),
+				options.GetBoolDefault("smallDate", true)))
+	} else if os.Stderr == writer {
+		streamHandler = StreamHandler(
+			colorable.NewColorableStderr(),
+			TerminalFormatHandler(
+				options.GetBoolDefault("noColor", false),
+				options.GetBoolDefault("smallDate", true)))
+	}
+	handler := CallerFileHandler(streamHandler)
+
+	if options.HandlerWrap != nil {
+		handler = options.HandlerWrap.SetChild(handler)
+	}
+	h.SetHandlers(handler, options)
+}
+
+// Use built in rolling function
+func (h *CompositeMultiHandler) SetTerminalFile(filePath string, options *LogOptions) {
+	writer := &lumberjack.Logger{
+		Filename:   filePath,
+		MaxSize:    options.GetIntDefault("maxSizeMB", 1024), // megabytes
+		MaxAge:     options.GetIntDefault("maxAgeDays", 7),   //days
+		MaxBackups: options.GetIntDefault("maxBackups", 7),
+		Compress:   options.GetBoolDefault("compress", true),
+	}
+	h.SetTerminal(writer, options)
+}
+
+func (h *CompositeMultiHandler) Disable(levels ...LogLevel) {
+	if len(levels) == 0 {
+		levels = LvlAllList
+	}
+	for _, level := range levels {
+		switch level {
+		case LvlDebug:
+			h.DebugHandler = nil
+		case LvlInfo:
+			h.InfoHandler = nil
+		case LvlWarn:
+			h.WarnHandler = nil
+		case LvlError:
+			h.ErrorHandler = nil
+		case LvlCrit:
+			h.CriticalHandler = nil
+		}
+	}
+}

--- a/logger/doc.go
+++ b/logger/doc.go
@@ -1,11 +1,15 @@
-
 /*
   Package logger contains filters and handles for the logging utilities in Revel.
   These facilities all currently use the logging library called log15 at
   https://github.com/inconshreveable/log15
 
-  Wrappers for the handlers are written here to provide a kind of isolation layer for Revel
-  in case sometime in the future we would like to switch to another source to implement logging
+	Defining handlers happens as follows
+	1) ALL handlers (log.all.output) replace any existing handlers
+	2) Output handlers (log.error.output) replace any existing handlers
+	3) Filter handlers (log.xxx.filter, log.xxx.nfilter) append to existing handlers,
+	   note log.all.filter is treated as a filter handler, so it will NOT replace existing ones
 
-  */
+
+
+*/
 package logger

--- a/logger/init.go
+++ b/logger/init.go
@@ -1,0 +1,189 @@
+package logger
+
+// Get all handlers based on the Config (if available)
+import (
+	"fmt"
+	"github.com/revel/config"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func InitializeFromConfig(basePath string, config *config.Context) (c *CompositeMultiHandler) {
+	// If running in test mode suppress anything that is not an error
+	if config != nil && config.BoolDefault(TEST_MODE_FLAG, false) {
+		// Preconfigure all the options
+		config.SetOption("log.info.output", "none")
+		config.SetOption("log.debug.output", "none")
+		config.SetOption("log.warn.output", "none")
+		config.SetOption("log.error.output", "stderr")
+		config.SetOption("log.crit.output", "stderr")
+	}
+
+	// If the configuration has an all option we can skip some
+	c, _ = NewCompositeMultiHandler()
+
+	// Filters are assigned first, non filtered items override filters
+	if config != nil && !config.BoolDefault(TEST_MODE_FLAG, false) {
+		initAllLog(c, basePath, config)
+	}
+	initLogLevels(c, basePath, config)
+	if c.CriticalHandler == nil && c.ErrorHandler != nil {
+		c.CriticalHandler = c.ErrorHandler
+	}
+	if config != nil && !config.BoolDefault(TEST_MODE_FLAG, false) {
+		initFilterLog(c, basePath, config)
+		if c.CriticalHandler == nil && c.ErrorHandler != nil {
+			c.CriticalHandler = c.ErrorHandler
+		}
+		initRequestLog(c, basePath, config)
+	}
+
+	return c
+}
+
+// Init the log.all configuration options
+func initAllLog(c *CompositeMultiHandler, basePath string, config *config.Context) {
+	if config != nil {
+		extraLogFlag := config.BoolDefault(SPECIAL_USE_FLAG, false)
+		if output, found := config.String("log.all.output"); found {
+			// Set all output for the specified handler
+			if extraLogFlag {
+				log.Printf("Adding standard handler for levels to >%s< ", output)
+			}
+			initHandlerFor(c, output, basePath, NewLogOptions(config, true, nil, LvlAllList...))
+		}
+	}
+}
+
+// Init the filter options
+// log.all.filter ....
+// log.error.filter ....
+func initFilterLog(c *CompositeMultiHandler, basePath string, config *config.Context) {
+
+	if config != nil {
+		extraLogFlag := config.BoolDefault(SPECIAL_USE_FLAG, false)
+
+		for _, logFilter := range logFilterList {
+			// Init for all filters
+			for _, name := range []string{"all", "debug", "info", "warn", "error", "crit",
+				"trace", // TODO trace is deprecated
+			} {
+				optionList := config.Options(logFilter.LogPrefix + name + logFilter.LogSuffix)
+				for _, option := range optionList {
+					splitOptions := strings.Split(option, ".")
+					keyMap := map[string]interface{}{}
+					for x := 3; x < len(splitOptions); x += 2 {
+						keyMap[splitOptions[x]] = splitOptions[x+1]
+					}
+					phandler := logFilter.parentHandler(keyMap)
+					if extraLogFlag {
+						log.Printf("Adding key map handler %s %s output %s", option, name, config.StringDefault(option, ""))
+						fmt.Printf("Adding key map handler %s %s output %s matching %#v\n", option, name, config.StringDefault(option, ""), keyMap)
+					}
+
+					if name == "all" {
+						initHandlerFor(c, config.StringDefault(option, ""), basePath, NewLogOptions(config, false, phandler))
+					} else {
+						initHandlerFor(c, config.StringDefault(option, ""), basePath, NewLogOptions(config, false, phandler, toLevel[name]))
+					}
+				}
+			}
+		}
+	}
+}
+
+// Init the log.error, log.warn etc configuration options
+func initLogLevels(c *CompositeMultiHandler, basePath string, config *config.Context) {
+	for _, name := range []string{"debug", "info", "warn", "error", "crit",
+		"trace", // TODO trace is deprecated
+	} {
+		if config != nil {
+			extraLogFlag := config.BoolDefault(SPECIAL_USE_FLAG, false)
+			output, found := config.String("log." + name + ".output")
+			if found {
+				if extraLogFlag {
+					log.Printf("Adding standard handler %s output %s", name, output)
+				}
+				initHandlerFor(c, output, basePath, NewLogOptions(config, true, nil, toLevel[name]))
+			}
+			// Gets the list of options with said prefix
+		} else {
+			initHandlerFor(c, "stderr", basePath, NewLogOptions(config, true, nil, toLevel[name]))
+		}
+	}
+}
+
+// Init the request log options
+func initRequestLog(c *CompositeMultiHandler, basePath string, config *config.Context) {
+	// Request logging to a separate output handler
+	// This takes the InfoHandlers and adds a MatchAbHandler handler to it to direct
+	// context with the word "section=requestlog" to that handler.
+	// Note if request logging is not enabled the MatchAbHandler will not be added and the
+	// request log messages will be sent out the INFO handler
+	outputRequest := "stdout"
+	if config != nil {
+		outputRequest = config.StringDefault("log.request.output", "")
+	}
+	oldInfo := c.InfoHandler
+	c.InfoHandler = nil
+	if outputRequest != "" {
+		initHandlerFor(c, outputRequest, basePath, NewLogOptions(config, false, nil, LvlInfo))
+	}
+	if c.InfoHandler != nil || oldInfo != nil {
+		if c.InfoHandler == nil {
+			c.InfoHandler = oldInfo
+		} else {
+			c.InfoHandler = MatchAbHandler("section", "requestlog", c.InfoHandler, oldInfo)
+		}
+	}
+}
+
+// Returns a handler for the level using the output string
+// Accept formats for output string are
+// LogFunctionMap[value] callback function
+// `stdout` `stderr` `full/file/path/to/location/app.log` `full/file/path/to/location/app.json`
+func initHandlerFor(c *CompositeMultiHandler, output, basePath string, options *LogOptions) {
+	if options.Ctx != nil {
+		options.SetExtendedOptions(
+			"noColor", !options.Ctx.BoolDefault("log.colorize", true),
+			"smallDate", options.Ctx.BoolDefault("log.smallDate", true),
+			"maxSize", options.Ctx.IntDefault("log.maxsize", 1024*10),
+			"maxAge", options.Ctx.IntDefault("log.maxage", 14),
+			"maxBackups", options.Ctx.IntDefault("log.maxbackups", 14),
+			"compressBackups", !options.Ctx.BoolDefault("log.compressBackups", true),
+		)
+	}
+
+	output = strings.TrimSpace(output)
+	if funcHandler, found := LogFunctionMap[output]; found {
+		funcHandler(c, options)
+	} else {
+		switch output {
+		case "":
+			fallthrough
+		case "off":
+		// No handler, discard data
+		default:
+			// Write to file specified
+			if !filepath.IsAbs(output) {
+				output = filepath.Join(basePath, output)
+			}
+
+			if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
+				log.Panic(err)
+			}
+
+			if strings.HasSuffix(output, "json") {
+				c.SetJsonFile(output, options)
+			} else {
+				// Override defaults for a terminal file
+				options.SetExtendedOptions("noColor", true)
+				options.SetExtendedOptions("smallDate", false)
+				c.SetTerminalFile(output, options)
+			}
+		}
+	}
+	return
+}

--- a/logger/init_test.go
+++ b/logger/init_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2012-2018 The Revel Framework Authors, All rights reserved.
+// Revel Framework source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+package logger_test
+
+import (
+	"github.com/revel/config"
+	"github.com/revel/revel/logger"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"strings"
+	"testing"
+)
+
+type (
+	// A counter for the tester
+	testCounter struct {
+		debug, info, warn, error, critical int
+	}
+	// The data to tes
+	testData struct {
+		config []string
+		result testResult
+		tc     *testCounter
+	}
+	// The test result
+	testResult struct {
+		debug, info, warn, error, critical int
+	}
+)
+
+// Single test cases
+var singleCases = []testData{
+	{config: []string{"log.crit.output"},
+		result: testResult{0, 0, 0, 0, 1}},
+	{config: []string{"log.error.output"},
+		result: testResult{0, 0, 0, 1, 1}},
+	{config: []string{"log.warn.output"},
+		result: testResult{0, 0, 1, 0, 0}},
+	{config: []string{"log.info.output"},
+		result: testResult{0, 1, 0, 0, 0}},
+	{config: []string{"log.debug.output"},
+		result: testResult{1, 0, 0, 0, 0}},
+}
+
+// Test singles
+func TestSingleCases(t *testing.T) {
+	rootLog := logger.New()
+	for _, testCase := range singleCases {
+		testCase.logTest(rootLog, t)
+		testCase.validate(t)
+	}
+}
+
+// Filter test cases
+var filterCases = []testData{
+	{config: []string{"log.crit.filter.module.app"},
+		result: testResult{0, 0, 0, 0, 1}},
+	{config: []string{"log.crit.filter.module.appa"},
+		result: testResult{0, 0, 0, 0, 0}},
+	{config: []string{"log.error.filter.module.app"},
+		result: testResult{0, 0, 0, 1, 1}},
+	{config: []string{"log.error.filter.module.appa"},
+		result: testResult{0, 0, 0, 0, 0}},
+	{config: []string{"log.warn.filter.module.app"},
+		result: testResult{0, 0, 1, 0, 0}},
+	{config: []string{"log.warn.filter.module.appa"},
+		result: testResult{0, 0, 0, 0, 0}},
+	{config: []string{"log.info.filter.module.app"},
+		result: testResult{0, 1, 0, 0, 0}},
+	{config: []string{"log.info.filter.module.appa"},
+		result: testResult{0, 0, 0, 0, 0}},
+	{config: []string{"log.debug.filter.module.app"},
+		result: testResult{1, 0, 0, 0, 0}},
+	{config: []string{"log.debug.filter.module.appa"},
+		result: testResult{0, 0, 0, 0, 0}},
+}
+
+// Filter test
+func TestFilterCases(t *testing.T) {
+	rootLog := logger.New("module", "app")
+	for _, testCase := range filterCases {
+		testCase.logTest(rootLog, t)
+		testCase.validate(t)
+	}
+}
+
+// Inverse test cases
+var nfilterCases = []testData{
+	{config: []string{"log.crit.nfilter.module.appa"},
+		result: testResult{0, 0, 0, 0, 1}},
+	{config: []string{"log.crit.nfilter.modules.appa"},
+		result: testResult{0, 0, 0, 0, 0}},
+	{config: []string{"log.crit.nfilter.module.app"},
+		result: testResult{0, 0, 0, 0, 0}},
+	{config: []string{"log.error.nfilter.module.appa"}, // Special case, when error is not nill critical inherits from error
+		result: testResult{0, 0, 0, 1, 1}},
+	{config: []string{"log.error.nfilter.module.app"},
+		result: testResult{0, 0, 0, 0, 0}},
+	{config: []string{"log.warn.nfilter.module.appa"},
+		result: testResult{0, 0, 1, 0, 0}},
+	{config: []string{"log.warn.nfilter.module.app"},
+		result: testResult{0, 0, 0, 0, 0}},
+	{config: []string{"log.info.nfilter.module.appa"},
+		result: testResult{0, 1, 0, 0, 0}},
+	{config: []string{"log.info.nfilter.module.app"},
+		result: testResult{0, 0, 0, 0, 0}},
+	{config: []string{"log.debug.nfilter.module.appa"},
+		result: testResult{1, 0, 0, 0, 0}},
+	{config: []string{"log.debug.nfilter.module.app"},
+		result: testResult{0, 0, 0, 0, 0}},
+}
+
+// Inverse test
+func TestNotFilterCases(t *testing.T) {
+	rootLog := logger.New("module", "app")
+	for _, testCase := range nfilterCases {
+		testCase.logTest(rootLog, t)
+		testCase.validate(t)
+	}
+}
+
+// off test cases
+var offCases = []testData{
+	{config: []string{"log.all.output", "log.error.output=off"},
+		result: testResult{1, 1, 1, 0, 1}},
+}
+
+// Off test
+func TestOffCases(t *testing.T) {
+	rootLog := logger.New("module", "app")
+	for _, testCase := range offCases {
+		testCase.logTest(rootLog, t)
+		testCase.validate(t)
+	}
+}
+
+// Duplicate test cases
+var duplicateCases = []testData{
+	{config: []string{"log.all.output", "log.error.output", "log.error.filter.module.app"},
+		result: testResult{1, 1, 1, 2, 1}},
+}
+
+// test duplicate cases
+func TestDuplicateCases(t *testing.T) {
+	rootLog := logger.New("module", "app")
+	for _, testCase := range duplicateCases {
+		testCase.logTest(rootLog, t)
+		testCase.validate(t)
+	}
+}
+
+// Contradicting cases
+var contradictCases = []testData{
+	{config: []string{"log.all.output", "log.error.output=off", "log.all.output"},
+		result: testResult{1, 1, 1, 0, 1}},
+	{config: []string{"log.all.output", "log.error.output=off", "log.debug.filter.module.app"},
+		result: testResult{2, 1, 1, 0, 1}},
+	{config: []string{"log.all.filter.module.app", "log.info.output=off", "log.info.filter.module.app"},
+		result: testResult{1, 2, 1, 1, 1}},
+	{config: []string{"log.all.output", "log.info.output=off", "log.info.filter.module.app"},
+		result: testResult{1, 1, 1, 1, 1}},
+}
+
+// Contradiction test
+func TestContradictCases(t *testing.T) {
+	rootLog := logger.New("module", "app")
+	for _, testCase := range contradictCases {
+		testCase.logTest(rootLog, t)
+		testCase.validate(t)
+	}
+}
+
+// All test cases
+var allCases = []testData{
+	{config: []string{"log.all.filter.module.app"},
+		result: testResult{1, 1, 1, 1, 1}},
+	{config: []string{"log.all.output"},
+		result: testResult{2, 2, 2, 2, 2}},
+}
+
+// All tests
+func TestAllCases(t *testing.T) {
+	rootLog := logger.New("module", "app")
+	for i, testCase := range allCases {
+		testCase.logTest(rootLog, t)
+		allCases[i] = testCase
+	}
+	rootLog = logger.New()
+	for i, testCase := range allCases {
+		testCase.logTest(rootLog, t)
+		allCases[i] = testCase
+	}
+	for _, testCase := range allCases {
+		testCase.validate(t)
+	}
+
+}
+
+func (c *testCounter) Log(r *logger.Record) error {
+	switch r.Level {
+	case logger.LvlDebug:
+		c.debug++
+	case logger.LvlInfo:
+		c.info++
+	case logger.LvlWarn:
+		c.warn++
+	case logger.LvlError:
+		c.error++
+	case logger.LvlCrit:
+		c.critical++
+	default:
+		panic("Unknown log level")
+	}
+	return nil
+}
+func (td *testData) logTest(rootLog logger.MultiLogger, t *testing.T) {
+	if td.tc == nil {
+		td.tc = &testCounter{}
+		counterInit(td.tc)
+	}
+	newContext := config.NewContext()
+	for _, i := range td.config {
+		iout := strings.Split(i, "=")
+		if len(iout) > 1 {
+			newContext.SetOption(iout[0], iout[1])
+		} else {
+			newContext.SetOption(i, "test")
+		}
+	}
+
+	newContext.SetOption("specialUseFlag", "true")
+
+	handler := logger.InitializeFromConfig("test", newContext)
+
+	rootLog.SetHandler(handler)
+
+	td.runLogTest(rootLog)
+}
+
+func (td *testData) runLogTest(log logger.MultiLogger) {
+	log.Debug("test")
+	log.Info("test")
+	log.Warn("test")
+	log.Error("test")
+	log.Crit("test")
+}
+
+func (td *testData) validate(t *testing.T) {
+	t.Logf("Test %#v expected %#v", td.tc, td.result)
+	assert.Equal(t, td.result.debug, td.tc.debug, "Debug failed "+strings.Join(td.config, " "))
+	assert.Equal(t, td.result.info, td.tc.info, "Info failed "+strings.Join(td.config, " "))
+	assert.Equal(t, td.result.warn, td.tc.warn, "Warn failed "+strings.Join(td.config, " "))
+	assert.Equal(t, td.result.error, td.tc.error, "Error failed "+strings.Join(td.config, " "))
+	assert.Equal(t, td.result.critical, td.tc.critical, "Critical failed "+strings.Join(td.config, " "))
+}
+
+// Add test to the function map
+func counterInit(tc *testCounter) {
+	logger.LogFunctionMap["test"] = func(c *logger.CompositeMultiHandler, logOptions *logger.LogOptions) {
+		// Output to the test log and the stdout
+		outHandler := logger.LogHandler(
+			logger.NewListLogHandler(tc,
+				logger.StreamHandler(os.Stdout, logger.TerminalFormatHandler(false, true))),
+		)
+		if logOptions.HandlerWrap != nil {
+			outHandler = logOptions.HandlerWrap.SetChild(outHandler)
+		}
+
+		c.SetHandlers(outHandler, logOptions)
+	}
+}

--- a/logger/log_function_map.go
+++ b/logger/log_function_map.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"os"
+)
+
+// The log function map can be added to, so that you can specify your own logging mechanism
+// it has defaults for off, stdout, stderr
+var LogFunctionMap = map[string]func(*CompositeMultiHandler, *LogOptions){
+	// Do nothing - set the logger off
+	"off": func(c *CompositeMultiHandler, logOptions *LogOptions) {
+		// Only drop the results if there is a parent handler defined
+		if logOptions.HandlerWrap != nil {
+			for _, l := range logOptions.Levels {
+				c.SetHandler(logOptions.HandlerWrap.SetChild(NilHandler()), logOptions.ReplaceExistingHandler, l)
+			}
+		} else {
+			// Clear existing handler
+			c.SetHandlers(NilHandler(), logOptions)
+		}
+	},
+	// Do nothing - set the logger off
+	"": func(*CompositeMultiHandler, *LogOptions) {},
+	// Set the levels to stdout, replace existing
+	"stdout": func(c *CompositeMultiHandler, logOptions *LogOptions) {
+		if logOptions.Ctx != nil {
+			logOptions.SetExtendedOptions(
+				"noColor", !logOptions.Ctx.BoolDefault("log.colorize", true),
+				"smallDate", logOptions.Ctx.BoolDefault("log.smallDate", true))
+		}
+		c.SetTerminal(os.Stdout, logOptions)
+	},
+	// Set the levels to stderr output to terminal
+	"stderr": func(c *CompositeMultiHandler, logOptions *LogOptions) {
+		c.SetTerminal(os.Stderr, logOptions)
+	},
+}

--- a/logger/revel_logger.go
+++ b/logger/revel_logger.go
@@ -1,0 +1,140 @@
+package logger
+
+import (
+	"fmt"
+	"github.com/revel/log15"
+	"log"
+	"os"
+)
+
+// This type implements the MultiLogger
+type RevelLogger struct {
+	log15.Logger
+}
+
+// Set the systems default logger
+// Default logs will be captured and handled by revel at level info
+func SetDefaultLog(fromLog MultiLogger) {
+	log.SetOutput(loggerRewrite{Logger: fromLog, Level: log15.LvlInfo, hideDeprecated: true})
+	// No need to show date and time, that will be logged with revel
+	log.SetFlags(0)
+}
+
+func (rl *RevelLogger) Debugf(msg string, param ...interface{}) {
+	rl.Debug(fmt.Sprintf(msg, param...))
+}
+
+// Print a formatted info message
+func (rl *RevelLogger) Infof(msg string, param ...interface{}) {
+	rl.Info(fmt.Sprintf(msg, param...))
+}
+
+// Print a formatted warn message
+func (rl *RevelLogger) Warnf(msg string, param ...interface{}) {
+	rl.Warn(fmt.Sprintf(msg, param...))
+}
+
+// Print a formatted error message
+func (rl *RevelLogger) Errorf(msg string, param ...interface{}) {
+	rl.Error(fmt.Sprintf(msg, param...))
+}
+
+// Print a formatted critical message
+func (rl *RevelLogger) Critf(msg string, param ...interface{}) {
+	rl.Crit(fmt.Sprintf(msg, param...))
+}
+
+// Print a formatted fatal message
+func (rl *RevelLogger) Fatalf(msg string, param ...interface{}) {
+	rl.Fatal(fmt.Sprintf(msg, param...))
+}
+
+// Print a formatted panic message
+func (rl *RevelLogger) Panicf(msg string, param ...interface{}) {
+	rl.Panic(fmt.Sprintf(msg, param...))
+}
+
+// Print a critical message and call os.Exit(1)
+func (rl *RevelLogger) Fatal(msg string, ctx ...interface{}) {
+	rl.Crit(msg, ctx...)
+	os.Exit(1)
+}
+
+// Print a critical message and panic
+func (rl *RevelLogger) Panic(msg string, ctx ...interface{}) {
+	rl.Crit(msg, ctx...)
+	panic(msg)
+}
+
+// Override log15 method
+func (rl *RevelLogger) New(ctx ...interface{}) MultiLogger {
+	old := &RevelLogger{Logger: rl.Logger.New(ctx...)}
+	return old
+}
+
+// Set the stack level to check for the caller
+func (rl *RevelLogger) SetStackDepth(amount int) MultiLogger {
+	rl.Logger.SetStackDepth(amount) // Ignore the logger returned
+	return rl
+}
+
+// Create a new logger
+func New(ctx ...interface{}) MultiLogger {
+	r := &RevelLogger{Logger: log15.New(ctx...)}
+	r.SetStackDepth(1)
+	return r
+}
+
+// Set the handler in the Logger
+func (rl *RevelLogger) SetHandler(h LogHandler) {
+	rl.Logger.SetHandler(callHandler(h.Log))
+}
+
+// The function wrapper to implement the callback
+type callHandler func(r *Record) error
+
+// Log implementation, reads the record and extracts the details from the log record
+// Hiding the implementation.
+func (c callHandler) Log(log *log15.Record) error {
+	ctx := log.Ctx
+	var ctxMap ContextMap
+	if len(ctx) > 0 {
+		ctxMap = make(ContextMap, len(ctx)/2)
+
+		for i := 0; i < len(ctx); i += 2 {
+			v := ctx[i]
+			key, ok := v.(string)
+			if !ok {
+				key = fmt.Sprintf("LOGGER_INVALID_KEY %v", v)
+			}
+			var value interface{}
+			if len(ctx) > i+1 {
+				value = ctx[i+1]
+			} else {
+				value = "LOGGER_VALUE_MISSING"
+			}
+			ctxMap[key] = value
+		}
+	}
+	r := &Record{Message: log.Msg, Context: ctxMap, Time: log.Time, Level: LogLevel(log.Lvl), Call: CallStack(log.Call)}
+	return c(r)
+}
+
+// Internally used contextMap, allows conversion of map to map[string]string
+type ContextMap map[string]interface{}
+
+// Convert the context map to be string only values, any non string values are ignored
+func (m ContextMap) StringMap() (newMap map[string]string) {
+	if m != nil {
+		newMap = map[string]string{}
+		for key, value := range m {
+			if svalue, isstring := value.(string); isstring {
+				newMap[key] = svalue
+			}
+		}
+	}
+	return
+}
+func (m ContextMap) Add(key string, value interface{}) {
+	m[key] = value
+}

--- a/logger/utils.go
+++ b/logger/utils.go
@@ -1,15 +1,9 @@
 package logger
 
 import (
-	"fmt"
-	"github.com/revel/config"
 	"github.com/revel/log15"
 	"gopkg.in/stack.v0"
 	"log"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 // Utility package to make existing logging backwards compatible
@@ -21,15 +15,15 @@ var (
 		"trace": LogLevel(log15.LvlDebug), // TODO trace is deprecated, replaced by debug
 	}
 )
+
 const (
 	// The test mode flag overrides the default log level and shows only errors
 	TEST_MODE_FLAG = "testModeFlag"
 	// The special use flag enables showing messages when the logger is setup
 	SPECIAL_USE_FLAG = "specialUseFlag"
-
-// Returns the logger for the name
 )
 
+// Returns the logger for the name
 func GetLogger(name string, logger MultiLogger) (l *log.Logger) {
 	switch name {
 	case "trace": // TODO trace is deprecated, replaced by debug
@@ -48,55 +42,6 @@ func GetLogger(name string, logger MultiLogger) (l *log.Logger) {
 
 	return l
 
-}
-
-// Get all handlers based on the Config (if available)
-func InitializeFromConfig(basePath string, config *config.Context) (c *CompositeMultiHandler) {
-	// If running in test mode suppress anything that is not an error
-	if  config!=nil && config.BoolDefault(TEST_MODE_FLAG,false) {
-		// Preconfigure all the options
-		config.SetOption("log.info.output","none")
-		config.SetOption("log.debug.output","none")
-		config.SetOption("log.warn.output","none")
-		config.SetOption("log.error.output","stderr")
-		config.SetOption("log.crit.output","stderr")
-	}
-
-
-	// If the configuration has an all option we can skip some
-	c, _ = NewCompositeMultiHandler()
-
-	// Filters are assigned first, non filtered items override filters
-	if config!=nil && !config.BoolDefault(TEST_MODE_FLAG,false) {
-		initAllLog(c, basePath, config)
-	}
-	initLogLevels(c, basePath, config)
-	if c.CriticalHandler == nil && c.ErrorHandler != nil {
-		c.CriticalHandler = c.ErrorHandler
-	}
-	if config!=nil && !config.BoolDefault(TEST_MODE_FLAG,false) {
-		initFilterLog(c, basePath, config)
-		if c.CriticalHandler == nil && c.ErrorHandler != nil {
-			c.CriticalHandler = c.ErrorHandler
-		}
-		initRequestLog(c, basePath, config)
-	}
-
-	return c
-}
-
-// Init the log.all configuration options
-func initAllLog(c *CompositeMultiHandler, basePath string, config *config.Context) {
-	if config != nil {
-		extraLogFlag := config.BoolDefault(SPECIAL_USE_FLAG, false)
-		if output, found := config.String("log.all.output"); found {
-			// Set all output for the specified handler
-			if extraLogFlag {
-				log.Printf("Adding standard handler for levels to >%s< ", output)
-			}
-			initHandlerFor(c, output, basePath, NewLogOptions(config, true, nil, LvlAllList...))
-		}
-	}
 }
 
 // Used by the initFilterLog to handle the filters
@@ -119,157 +64,6 @@ var logFilterList = []struct {
 		})
 	},
 }}
-
-// Init the filter options
-// log.all.filter ....
-// log.error.filter ....
-func initFilterLog(c *CompositeMultiHandler, basePath string, config *config.Context) {
-
-	if config != nil {
-		extraLogFlag := config.BoolDefault(SPECIAL_USE_FLAG, false)
-
-		// The commands to use
-		logFilterList := []struct {
-			LogPrefix, LogSuffix string
-			parentHandler        func(map[string]interface{}) ParentLogHandler
-		}{{
-			"log.", ".filter",
-			func(keyMap map[string]interface{}) ParentLogHandler {
-				return NewParentLogHandler(func(child LogHandler) LogHandler {
-					return MatchMapHandler(keyMap, child)
-				})
-
-			},
-		}, {
-			"log.", ".nfilter",
-			func(keyMap map[string]interface{}) ParentLogHandler {
-				return NewParentLogHandler(func(child LogHandler) LogHandler {
-					return NotMatchMapHandler(keyMap, child)
-				})
-			},
-		}}
-
-		for _, logFilter := range logFilterList {
-			// Init for all filters
-			for _, name := range []string{"all", "debug", "info", "warn", "error", "crit",
-				"trace", // TODO trace is deprecated
-			} {
-				optionList := config.Options(logFilter.LogPrefix + name + logFilter.LogSuffix)
-				for _, option := range optionList {
-					splitOptions := strings.Split(option, ".")
-					keyMap := map[string]interface{}{}
-					for x := 3; x < len(splitOptions); x += 2 {
-						keyMap[splitOptions[x]] = splitOptions[x+1]
-					}
-					phandler := logFilter.parentHandler(keyMap)
-					if extraLogFlag {
-						log.Printf("Adding key map handler %s %s output %s", option, name, config.StringDefault(option, ""))
-					}
-
-					if name == "all" {
-						initHandlerFor(c, config.StringDefault(option, ""), basePath, NewLogOptions(config, false, phandler))
-					} else {
-						initHandlerFor(c, config.StringDefault(option, ""), basePath, NewLogOptions(config, false, phandler, toLevel[name]))
-					}
-				}
-			}
-		}
-	}
-}
-
-// Init the log.error, log.warn etc configuration options
-func initLogLevels(c *CompositeMultiHandler, basePath string, config *config.Context) {
-	for _, name := range []string{"debug", "info", "warn", "error", "crit",
-		"trace", // TODO trace is deprecated
-	} {
-		if config != nil {
-			extraLogFlag := config.BoolDefault(SPECIAL_USE_FLAG, false)
-			output, found := config.String("log." + name + ".output")
-			if found {
-				if extraLogFlag {
-					log.Printf("Adding standard handler %s output %s", name, output)
-				}
-				initHandlerFor(c, output, basePath, NewLogOptions(config, true, nil, toLevel[name]))
-			}
-			// Gets the list of options with said prefix
-		} else {
-			initHandlerFor(c, "stderr", basePath, NewLogOptions(config, true, nil, toLevel[name]))
-		}
-	}
-}
-
-// Init the request log options
-func initRequestLog(c *CompositeMultiHandler, basePath string, config *config.Context) {
-	// Request logging to a separate output handler
-	// This takes the InfoHandlers and adds a MatchAbHandler handler to it to direct
-	// context with the word "section=requestlog" to that handler.
-	// Note if request logging is not enabled the MatchAbHandler will not be added and the
-	// request log messages will be sent out the INFO handler
-	outputRequest := "stdout"
-	if config != nil {
-		outputRequest = config.StringDefault("log.request.output", "")
-	}
-	oldInfo := c.InfoHandler
-	c.InfoHandler = nil
-	if outputRequest != "" {
-		initHandlerFor(c, outputRequest, basePath, NewLogOptions(config, false, nil, LvlInfo))
-	}
-	if c.InfoHandler != nil || oldInfo != nil {
-		if c.InfoHandler == nil {
-			c.InfoHandler = oldInfo
-		} else {
-			c.InfoHandler = MatchAbHandler("section", "requestlog", c.InfoHandler, oldInfo)
-		}
-	}
-}
-
-// Returns a handler for the level using the output string
-// Accept formats for output string are
-// LogFunctionMap[value] callback function
-// `stdout` `stderr` `full/file/path/to/location/app.log` `full/file/path/to/location/app.json`
-func initHandlerFor(c *CompositeMultiHandler, output, basePath string, options *LogOptions) {
-	if options.Ctx != nil {
-		options.SetExtendedOptions(
-			"noColor", !options.Ctx.BoolDefault("log.colorize", true),
-			"smallDate", options.Ctx.BoolDefault("log.smallDate", true),
-			"maxSize", options.Ctx.IntDefault("log.maxsize", 1024*10),
-			"maxAge", options.Ctx.IntDefault("log.maxage", 14),
-			"maxBackups", options.Ctx.IntDefault("log.maxbackups", 14),
-			"compressBackups", !options.Ctx.BoolDefault("log.compressBackups", true),
-		)
-	}
-
-	output = strings.TrimSpace(output)
-	if funcHandler, found := LogFunctionMap[output]; found {
-		funcHandler(c, options)
-	} else {
-		switch output {
-		case "":
-			fallthrough
-		case "off":
-			// No handler, discard data
-		default:
-			// Write to file specified
-			if !filepath.IsAbs(output) {
-				output = filepath.Join(basePath, output)
-			}
-
-			if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
-				log.Panic(err)
-			}
-
-			if strings.HasSuffix(output, "json") {
-				c.SetJsonFile(output, options)
-			} else {
-				// Override defaults for a terminal file
-				options.SetExtendedOptions("noColor", true)
-				options.SetExtendedOptions("smallDate", false)
-				c.SetTerminalFile(output, options)
-			}
-		}
-	}
-	return
-}
 
 // This structure and method will handle the old output format and log it to the new format
 type loggerRewrite struct {
@@ -310,64 +104,7 @@ func (lr loggerRewrite) Write(p []byte) (n int, err error) {
 
 // For logging purposes the call stack can be used to record the stack trace of a bad error
 // simply pass it as a context field in your log statement like
-// `controller.Log.Critc("This should not occur","stack",revel.NewCallStack())`
+// `controller.Log.Crit("This should not occur","stack",revel.NewCallStack())`
 func NewCallStack() interface{} {
 	return stack.Trace()
-}
-
-// Currently the only requirement for the callstack is to support the Formatter method
-// which stack.Call does
-type CallStack interface {
-	fmt.Formatter
-
-}
-// Call to define a handler function for the logs
-func HandlerFunc(log func(message string, time time.Time, level LogLevel, call CallStack, context ContextMap) error) LogHandler {
-	return callHandler(log)
-}
-
-// The function wrapper to implement the callback
-type callHandler func(message string, time time.Time, level LogLevel, call CallStack, context ContextMap) error
-
-// Log implementation, reads the record and extracts the details from the log record
-// Hiding the implementation.
-func (c callHandler) Log(log *log15.Record) error {
-	ctx := log.Ctx
-	var ctxMap ContextMap
-	if len(ctx) > 0 {
-		ctxMap = make(ContextMap, len(ctx)/2)
-
-		for i := 0; i < len(ctx); i += 2 {
-			v := ctx[i]
-			key, ok := v.(string)
-			if !ok {
-				key = fmt.Sprintf("LOGGER_INVALID_KEY %v", v)
-			}
-			var value interface{}
-			if len(ctx) > i+1 {
-				value = ctx[i+1]
-			} else {
-				value = "LOGGER_VALUE_MISSING"
-			}
-			ctxMap[key] = value
-		}
-	}
-
-	return c(log.Msg, log.Time, LogLevel(log.Lvl), CallStack(log.Call), ctxMap)
-}
-
-// Internally used contextMap, allows conversion of map to map[string]string
-type ContextMap map[string]interface{}
-
-// Convert the context map to be string only values, any non string values are ignored
-func (m ContextMap) StringMap() (newMap map[string]string) {
-	if m != nil {
-		newMap = map[string]string{}
-		for key, value := range m {
-			if svalue, isstring := value.(string); isstring {
-				newMap[key] = svalue
-			}
-		}
-	}
-	return
 }

--- a/logger/wrap_handlers.go
+++ b/logger/wrap_handlers.go
@@ -1,0 +1,98 @@
+package logger
+
+// FuncHandler returns a Handler that logs records with the given
+// function.
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+)
+
+// Function handler wraps the declared function and returns the handler for it
+func FuncHandler(fn func(r *Record) error) LogHandler {
+	return funcHandler(fn)
+}
+
+// The type decleration for the function
+type funcHandler func(r *Record) error
+
+// The implementation of the Log
+func (h funcHandler) Log(r *Record) error {
+	return h(r)
+}
+
+// This function allows you to do a full declaration for the log,
+// it is recommended you use FuncHandler instead
+func HandlerFunc(log func(message string, time time.Time, level LogLevel, call CallStack, context ContextMap) error) LogHandler {
+	return remoteHandler(log)
+}
+
+// The type used for the HandlerFunc
+type remoteHandler func(message string, time time.Time, level LogLevel, call CallStack, context ContextMap) error
+
+// The Log implementation
+func (c remoteHandler) Log(record *Record) error {
+	return c(record.Message, record.Time, record.Level, record.Call, record.Context)
+}
+
+// SyncHandler can be wrapped around a handler to guarantee that
+// only a single Log operation can proceed at a time. It's necessary
+// for thread-safe concurrent writes.
+func SyncHandler(h LogHandler) LogHandler {
+	var mu sync.Mutex
+	return FuncHandler(func(r *Record) error {
+		defer mu.Unlock()
+		mu.Lock()
+		return h.Log(r)
+	})
+}
+
+// LazyHandler writes all values to the wrapped handler after evaluating
+// any lazy functions in the record's context. It is already wrapped
+// around StreamHandler and SyslogHandler in this library, you'll only need
+// it if you write your own Handler.
+func LazyHandler(h LogHandler) LogHandler {
+	return FuncHandler(func(r *Record) error {
+		for k, v := range r.Context {
+			if lz, ok := v.(Lazy); ok {
+				value, err := evaluateLazy(lz)
+				if err != nil {
+					r.Context[errorKey] = "bad lazy " + k
+				} else {
+					v = value
+				}
+			}
+		}
+
+		return h.Log(r)
+	})
+}
+
+func evaluateLazy(lz Lazy) (interface{}, error) {
+	t := reflect.TypeOf(lz.Fn)
+
+	if t.Kind() != reflect.Func {
+		return nil, fmt.Errorf("INVALID_LAZY, not func: %+v", lz.Fn)
+	}
+
+	if t.NumIn() > 0 {
+		return nil, fmt.Errorf("INVALID_LAZY, func takes args: %+v", lz.Fn)
+	}
+
+	if t.NumOut() == 0 {
+		return nil, fmt.Errorf("INVALID_LAZY, no func return val: %+v", lz.Fn)
+	}
+
+	value := reflect.ValueOf(lz.Fn)
+	results := value.Call([]reflect.Value{})
+	if len(results) == 1 {
+		return results[0].Interface(), nil
+	} else {
+		values := make([]interface{}, len(results))
+		for i, v := range results {
+			values[i] = v.Interface()
+		}
+		return values, nil
+	}
+}

--- a/revel_hooks.go
+++ b/revel_hooks.go
@@ -1,0 +1,103 @@
+package revel
+
+import (
+	"sort"
+)
+
+// The list of startup hooks
+type (
+	// The startup hooks structure
+	RevelHook struct {
+		order int    // The order
+		f     func() // The function to call
+	}
+
+	RevelHooks []RevelHook
+)
+
+var (
+	// The local instance of the list
+	startupHooks RevelHooks
+
+	// The instance of the list
+	shutdownHooks RevelHooks
+)
+
+// Called to run the hooks
+func (r RevelHooks) Run() {
+	serverLogger.Infof("There is %d hooks need to run ...", len(r))
+	sort.Sort(r)
+	for i, hook := range r {
+		utilLog.Infof("Run the %d hook ...", i+1)
+		hook.f()
+	}
+}
+
+// Adds a new function hook, using the order
+func (r RevelHooks) Add(fn func(), order ...int) RevelHooks {
+	o := 1
+	if len(order) > 0 {
+		o = order[0]
+	}
+	return append(r, RevelHook{order: o, f: fn})
+}
+
+// Sorting function
+func (slice RevelHooks) Len() int {
+	return len(slice)
+}
+
+// Sorting function
+func (slice RevelHooks) Less(i, j int) bool {
+	return slice[i].order < slice[j].order
+}
+
+// Sorting function
+func (slice RevelHooks) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}
+
+// OnAppStart registers a function to be run at app startup.
+//
+// The order you register the functions will be the order they are run.
+// You can think of it as a FIFO queue.
+// This process will happen after the config file is read
+// and before the server is listening for connections.
+//
+// Ideally, your application should have only one call to init() in the file init.go.
+// The reason being that the call order of multiple init() functions in
+// the same package is undefined.
+// Inside of init() call revel.OnAppStart() for each function you wish to register.
+//
+// Example:
+//
+//      // from: yourapp/app/controllers/somefile.go
+//      func InitDB() {
+//          // do DB connection stuff here
+//      }
+//
+//      func FillCache() {
+//          // fill a cache from DB
+//          // this depends on InitDB having been run
+//      }
+//
+//      // from: yourapp/app/init.go
+//      func init() {
+//          // set up filters...
+//
+//          // register startup functions
+//          revel.OnAppStart(InitDB)
+//          revel.OnAppStart(FillCache)
+//      }
+//
+// This can be useful when you need to establish connections to databases or third-party services,
+// setup app components, compile assets, or any thing you need to do between starting Revel and accepting connections.
+//
+func OnAppStart(f func(), order ...int) {
+	startupHooks = startupHooks.Add(f, order...)
+}
+
+// Called to add a new stop hook
+func OnAppStop(f func(), order ...int) {
+	shutdownHooks = shutdownHooks.Add(f, order...)
+}

--- a/template.go
+++ b/template.go
@@ -469,7 +469,8 @@ func (i *TemplateView) Content() (content []string) {
 			content = append(content, string(reader.Bytes()))
 		}
 	}
-	return nil
+
+	return content
 }
 
 func NewBaseTemplate(templateName, filePath, basePath string, fileBytes []byte) *TemplateView {

--- a/template_adapter_go.go
+++ b/template_adapter_go.go
@@ -91,7 +91,6 @@ func (engine *GoEngine) ParseAndAdd(baseTemplate *TemplateView) error {
 	tpl, err := engine.templateSet.New(baseTemplate.TemplateName).Parse(templateSource)
 	if nil != err {
 		_, line, description := ParseTemplateError(err)
-		println("*** Returned *Error type")
 		return &Error{
 			Title:       "Template Compilation Error",
 			Path:        baseTemplate.TemplateName,

--- a/util.go
+++ b/util.go
@@ -28,8 +28,8 @@ const (
 
 var (
 	cookieKeyValueParser = regexp.MustCompile("\x00([^:]*):([^\x00]*)\x00")
-	hdrForwardedFor      = http.CanonicalHeaderKey("X-Forwarded-For")
-	hdrRealIP            = http.CanonicalHeaderKey("X-Real-Ip")
+	HdrForwardedFor      = http.CanonicalHeaderKey("X-Forwarded-For")
+	HdrRealIP            = http.CanonicalHeaderKey("X-Real-Ip")
 	utilLog              = RevelLog.New("section", "util")
 	mimeConfig           *config.Context
 )
@@ -195,7 +195,7 @@ func Equal(a, b interface{}) bool {
 func ClientIP(r *Request) string {
 	if Config.BoolDefault("app.behind.proxy", false) {
 		// Header X-Forwarded-For
-		if fwdFor := strings.TrimSpace(r.GetHttpHeader(hdrForwardedFor)); fwdFor != "" {
+		if fwdFor := strings.TrimSpace(r.GetHttpHeader(HdrForwardedFor)); fwdFor != "" {
 			index := strings.Index(fwdFor, ",")
 			if index == -1 {
 				return fwdFor
@@ -204,7 +204,7 @@ func ClientIP(r *Request) string {
 		}
 
 		// Header X-Real-Ip
-		if realIP := strings.TrimSpace(r.GetHttpHeader(hdrRealIP)); realIP != "" {
+		if realIP := strings.TrimSpace(r.GetHttpHeader(HdrRealIP)); realIP != "" {
 			return realIP
 		}
 	}


### PR DESCRIPTION
Updated test cases
Updated shutdown to support windows environment
Patched shutdown support to make it work through the event engine
Added ENGINE_SHUTDOWN_REQUEST to events, raising this event will cause the server to shutdown
Assigned Server engines to receive revel.Events
Added revel.OnAppStop hooks - breaking change, was revel.OnAppShutdown
Removed revel.OnAppShutdown
Normalized startup / shutdown hooks into their own package
