### PR TITLE
Fix spelling errors from go report

### DIFF
--- a/cache/redis.go
+++ b/cache/redis.go
@@ -175,7 +175,7 @@ func (c RedisCache) Increment(key string, delta uint64) (uint64, error) {
 	defer func() {
 		_ = conn.Close()
 	}()
-	// Check for existance *before* increment as per the cache contract.
+	// Check for existence *before* increment as per the cache contract.
 	// redis will auto create the key, and we don't want that. Since we need to do increment
 	// ourselves instead of natively via INCRBY (redis doesn't support wrapping), we get the value
 	// and do the exists check this way to minimize calls to Redis
@@ -202,7 +202,7 @@ func (c RedisCache) Decrement(key string, delta uint64) (newValue uint64, err er
 	defer func() {
 		_ = conn.Close()
 	}()
-	// Check for existance *before* increment as per the cache contract.
+	// Check for existence *before* increment as per the cache contract.
 	// redis will auto create the key, and we don't want that, hence the exists call
 	existed, err := exists(conn, key)
 	if err != nil {

--- a/module.go
+++ b/module.go
@@ -65,12 +65,12 @@ func (m *Module) Namespace() (namespace string) {
 
 // Returns the named controller and action that is in this module
 func (m *Module) ControllerByName(name, action string) (ctype *ControllerType) {
-	comparision := name
+	comparison := name
 	if strings.Index(name, namespaceSeperator) < 0 {
-		comparision = m.Namespace() + name
+		comparison = m.Namespace() + name
 	}
 	for _, c := range m.ControllerTypeList {
-		if c.Name() == comparision {
+		if c.Name() == comparison {
 			ctype = c
 			break
 		}

--- a/template_functions.go
+++ b/template_functions.go
@@ -257,7 +257,7 @@ func TimeAgo(args ...interface{}) string {
 	var viewArgs interface{}
 	switch len(args) {
 	case 0:
-		templateLog.Error("TimeAgo: No arguements passed to timeago")
+		templateLog.Error("TimeAgo: No arguments passed to timeago")
 	case 1:
 		// only the time is passed in
 		datetime = args[0].(time.Time)


### PR DESCRIPTION
Fixed the spelling errors found by misspell in [Go Report](https://goreportcard.com/report/github.com/revel/revel#misspell)