### PR TITLE
Bug fix, not reuse controllers

### DIFF
--- a/model/revel_container.go
+++ b/model/revel_container.go
@@ -1,0 +1,14 @@
+package model
+
+import "github.com/revel/revel/utils"
+
+// The single instance object that has the config populated to it
+type RevelContainer struct {
+	Controller struct {
+		Reuse              bool                              // True if the controllers are reused Set via revel.controller.reuse
+		Stack              *utils.SimpleLockStack            // size set by revel.controller.stack,  revel.controller.maxstack
+		CachedMap          map[string]*utils.SimpleLockStack // The map of reusable controllers
+		CachedStackSize    int                               // The default size of each stack in CachedMap Set via revel.cache.controller.stack
+		CachedStackMaxSize int                               // The max size of each stack in CachedMap Set via revel.cache.controller.maxstack
+	}
+}

--- a/revel.go
+++ b/revel.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"github.com/revel/config"
 	"github.com/revel/revel/logger"
+	"github.com/revel/revel/model"
 )
 
 const (
@@ -28,6 +29,7 @@ const (
 
 // App details
 var (
+	RevelConfig *model.RevelContainer
 	AppName    string // e.g. "sample"
 	AppRoot    string // e.g. "/app1"
 	BasePath   string // e.g. "$GOPATH/src/corp/sample"
@@ -94,6 +96,7 @@ var (
 //   srcPath - the path to the source directory, containing Revel and the app.
 //     If not specified (""), then a functioning Go installation is required.
 func Init(inputmode, importPath, srcPath string) {
+	RevelConfig = &model.RevelContainer{}
 	// Ignore trailing slashes.
 	ImportPath = strings.TrimRight(importPath, "/")
 	SourcePath = srcPath

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"github.com/revel/revel/utils"
 )
 
 // Revel's variables server, router, etc
@@ -132,11 +133,18 @@ func InitServerEngine(port int, serverEngine string) {
 
 // Initialize the controller stack for the application
 func initControllerStack() {
-	controllerStack = NewStackLock(
-		Config.IntDefault("revel.controller.stack", 10),
-		Config.IntDefault("revel.controller.maxstack", 200), func() interface{} { return NewControllerEmpty() })
-	cachedControllerStackSize = Config.IntDefault("revel.cache.controller.stack", 10)
-	cachedControllerStackMaxSize = Config.IntDefault("revel.cache.controller.maxstack", 100)
+	RevelConfig.Controller.Reuse = Config.BoolDefault("revel.controller.reuse",true)
+
+	if RevelConfig.Controller.Reuse {
+		RevelConfig.Controller.Stack = utils.NewStackLock(
+			Config.IntDefault("revel.controller.stack", 10),
+			Config.IntDefault("revel.controller.maxstack", 200), func() interface{} {
+				return NewControllerEmpty()
+			})
+		RevelConfig.Controller.CachedStackSize = Config.IntDefault("revel.cache.controller.stack", 10)
+		RevelConfig.Controller.CachedStackMaxSize = Config.IntDefault("revel.cache.controller.maxstack", 100)
+		RevelConfig.Controller.CachedMap = map[string]*utils.SimpleLockStack{}
+	}
 }
 
 // Called to stop the server

--- a/utils/simplestack.go
+++ b/utils/simplestack.go
@@ -1,4 +1,4 @@
-package revel
+package utils
 
 import (
 	"fmt"

--- a/utils/simplestack_test.go
+++ b/utils/simplestack_test.go
@@ -1,4 +1,4 @@
-package revel
+package utils
 
 import (
 	"testing"


### PR DESCRIPTION
Moved SimpleStack into utils folder
Added RevelContainer
Moved controller stacks inside revelcontainer
Added option to not reuse controllers via `revel.controller.reuse`