### PR TITLE
Remove a stray println call.

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -234,7 +234,6 @@ func (s Session) Serialize() map[string]string {
 			newMap[key] = value.(string)
 			continue
 		}
-		println("Serialize the data for", key)
 		if data, err := json.Marshal(value); err != nil {
 			sessionLog.Error("Unable to marshal session ", "key", key, "error", err)
 			continue


### PR DESCRIPTION
Looks like it was added for debugging and never removed, now it only creates noise in logs.