### PR TITLE
Fix bug where action is invoked even when Before interceptor returns non-nil value

### DIFF
--- a/before_after_filter.go
+++ b/before_after_filter.go
@@ -22,6 +22,7 @@ func BeforeAfterFilter(c *Controller, fc []Filter) {
 	}()
 	if resultValue := beforeAfterFilterInvoke(BEFORE, c); resultValue != nil && !resultValue.IsNil() {
 		c.Result = resultValue.Interface().(Result)
+		return
 	}
 	fc[0](c, fc[1:])
 	if resultValue := beforeAfterFilterInvoke(AFTER, c); resultValue != nil && !resultValue.IsNil() {

--- a/before_after_filter_test.go
+++ b/before_after_filter_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 The Revel Framework Authors, All rights reserved.
+// Revel Framework source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+package revel
+
+import (
+	"testing"
+)
+
+type bafTestController struct {
+	*Controller
+}
+
+func (c bafTestController) Before() (Result, bafTestController) {
+	return c.Redirect("http://www.example.com"), c
+}
+
+func (c bafTestController) Index() Result {
+	// We shouldn't get here
+	panic("Should not be called")
+}
+
+type failingFilter struct {
+	t *testing.T
+}
+
+func (f failingFilter) FailIfCalled(c *Controller, filterChain []Filter) {
+	f.t.Error("Filter should not have been called")
+}
+
+func TestInterceptorsNotCalledIfBeforeReturns(t *testing.T) {
+	Init("prod", "github.com/revel/revel/testdata", "")
+	controllers = make(map[string]*ControllerType)
+	RegisterController((*bafTestController)(nil), []*MethodType{
+		{
+			Name: "Before",
+		},
+		{
+			Name: "Index",
+		},
+	})
+
+	c := NewControllerEmpty()
+	err := c.SetAction("bafTestController", "Index")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	BeforeAfterFilter(c, []Filter{failingFilter{t}.FailIfCalled})
+}


### PR DESCRIPTION
Adjusts the `BeforeAfterFilter` so that it doesn't continue to execute interceptors or actions if the BEFORE function returns a value.

Adds a new test file, `before_after_filter_test.go`, which verifies this behaviour.

Fixes #1433.