### PR TITLE
Update server_adapter_go.go

### DIFF
--- a/server_adapter_go.go
+++ b/server_adapter_go.go
@@ -495,9 +495,7 @@ func (r *GoResponse) WriteStream(name string, contentlen int64, modtime time.Tim
 		if _, err := io.Copy(r.Writer, reader); err != nil {
 			r.Original.WriteHeader(http.StatusInternalServerError)
 			return err
-		} else {
-			r.Original.WriteHeader(http.StatusOK)
-		}
+		} 
 	}
 	return nil
 }


### PR DESCRIPTION
Avoid message "INFO  02:07:49    app server_adapter_go.go:499: http: superfluous response.WriteHeader call from github.com/revel/revel.(*GoResponse).WriteStream (server_adapter_go.go:499)   section=system"