### PR TITLE
SameSite cookie support

### DIFF
--- a/flash.go
+++ b/flash.go
@@ -59,6 +59,7 @@ func FlashFilter(c *Controller, fc []Filter) {
 		Value:    url.QueryEscape(flashValue),
 		HttpOnly: true,
 		Secure:   CookieSecure,
+		SameSite: CookieSameSite,
 		Path:     "/",
 	})
 }

--- a/revel.go
+++ b/revel.go
@@ -6,6 +6,7 @@ package revel
 
 import (
 	"go/build"
+	"net/http"
 	"path/filepath"
 	"strings"
 
@@ -73,7 +74,8 @@ var (
 	// Cookie domain
 	CookieDomain string
 	// Cookie flags
-	CookieSecure bool
+	CookieSecure   bool
+	CookieSameSite http.SameSite
 
 	// Revel request access log, not exposed from package.
 	// However output settings can be controlled from app.conf
@@ -174,6 +176,18 @@ func Init(inputmode, importPath, srcPath string) {
 	CookiePrefix = Config.StringDefault("cookie.prefix", "REVEL")
 	CookieDomain = Config.StringDefault("cookie.domain", "")
 	CookieSecure = Config.BoolDefault("cookie.secure", HTTPSsl)
+
+	switch Config.StringDefault("cookie.samesite", "") {
+	case "lax":
+		CookieSameSite = http.SameSiteLaxMode
+	case "strict":
+		CookieSameSite = http.SameSiteStrictMode
+	case "none":
+		CookieSameSite = http.SameSiteNoneMode
+	default:
+		CookieSameSite = http.SameSiteDefaultMode
+	}
+
 	if secretStr := Config.StringDefault("app.secret", ""); secretStr != "" {
 		SetSecretKey([]byte(secretStr))
 	}

--- a/session_adapter_cookie.go
+++ b/session_adapter_cookie.go
@@ -136,6 +136,7 @@ func (cse *SessionCookieEngine) GetCookie(s session.Session) *http.Cookie {
 		Path:     "/",
 		HttpOnly: true,
 		Secure:   CookieSecure,
+		SameSite: CookieSameSite,
 		Expires:  ts.UTC(),
 		MaxAge:   int(cse.ExpireAfterDuration.Seconds()),
 	}

--- a/validation.go
+++ b/validation.go
@@ -295,6 +295,7 @@ func ValidationFilter(c *Controller, fc []Filter) {
 				Path:     "/",
 				HttpOnly: true,
 				Secure:   CookieSecure,
+				SameSite: CookieSameSite,
 			})
 		} else if hasCookie {
 			c.SetCookie(&http.Cookie{
@@ -304,6 +305,7 @@ func ValidationFilter(c *Controller, fc []Filter) {
 				Path:     "/",
 				HttpOnly: true,
 				Secure:   CookieSecure,
+				SameSite: CookieSameSite,
 			})
 		}
 	}


### PR DESCRIPTION
Support SameSite cookie parameter

This has become an issue when developing locally, because most browsers now give warnings if you don't have SameSite set, and the warning states they will soon ban cookies that don't have SameSite or Secure set. So this would allow you to set SameSite so it'll work when developing locally over HTTP not HTTPS.

I'm not sure, but maybe it should default to 'strict' for local development so people don't get stung by this when browsers begin to enforce this rule; it seems like it'd be safer to leave this as 'default' for production so as to not break anyone's sites - however it might even better to default it to 'strict' for production for new sites too? Open to the maintainers thoughts on those issues.

Thanks all