### PR TITLE
Correction garyburd/redigo import

### DIFF
--- a/cache/redis.go
+++ b/cache/redis.go
@@ -7,7 +7,7 @@ package cache
 import (
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/revel/revel"
 )
 


### PR DESCRIPTION
The package github.com/garyburd/redigo doesn't exist anymore.
Just replaced the import by the new package : https://github.com/gomodule/redigo/