### PR TITLE
Added X-HTTP-Method-Override validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/router.go
+++ b/router.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/revel/pathtree"
 	"github.com/revel/revel/logger"
+	"golang.org/x/net/http/httpguts"
 )
 
 const (
@@ -170,6 +171,12 @@ type Router struct {
 func (router *Router) Route(req *Request) (routeMatch *RouteMatch) {
 	// Override method if set in header
 	if method := req.GetHttpHeader("X-HTTP-Method-Override"); method != "" && req.Method == "POST" {
+		isNotToken := func(r rune) bool {
+			return !httpguts.IsTokenRune(r)
+		}
+		if strings.IndexFunc(method, isNotToken) != -1 {
+			return nil
+		}
 		req.Method = method
 	}
 


### PR DESCRIPTION
This MR will make sure that the value passed in `X-HTTP-Method-Override` is a valid HTTP token as required in the RFC. The validation resolves a security issue that can occur when Revel is used behind reverse proxies. Because of how the route matching is done, one could make a request to `/site` with the header `X-HTTP-Method-Override: POST/admin` and it would be routed to `/admin/site`. This could be exploited if the security setup relied on a proxy blocking certain path or if the proxy added a trusted prefix to every request.  

I don't know if this is the best way of resolving the issue (or if it is even fully resolved). If you want to implement it another way please do, I just wanted to bring it to attention.