### PR TITLE
Added verification of X-HTTP-Method-Override before use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/router.go
+++ b/router.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/revel/pathtree"
 	"github.com/revel/revel/logger"
+	"golang.org/x/net/http/httpguts"
 )
 
 const (
@@ -160,6 +161,16 @@ func treePath(method, path string) string {
 	return "/" + method + path
 }
 
+//validMethod is copied from net/http/request.go
+func validMethod(method string) bool {
+	return len(method) > 0 && strings.IndexFunc(method, isNotToken) == -1
+}
+
+//isNotToken is copied from net/http/http.go
+func isNotToken(r rune) bool {
+	return !httpguts.IsTokenRune(r)
+}
+
 type Router struct {
 	Routes []*Route
 	Tree   *pathtree.Node
@@ -169,7 +180,7 @@ type Router struct {
 
 func (router *Router) Route(req *Request) (routeMatch *RouteMatch) {
 	// Override method if set in header
-	if method := req.GetHttpHeader("X-HTTP-Method-Override"); method != "" && req.Method == "POST" {
+	if method := req.GetHttpHeader("X-HTTP-Method-Override"); method != "" && req.Method == "POST" && validMethod(method) {
 		req.Method = method
 	}
 

--- a/router.go
+++ b/router.go
@@ -162,13 +162,13 @@ func treePath(method, path string) string {
 }
 
 //validMethod is copied from net/http/request.go
-//its used to validate the X-HTTP-Method-Override so that it only may contain valid characters for a http method in a identical way to how net/http validates method.
+// used to validate the X-HTTP-Method-Override so that only valid HTTP method characters are allowed (in the same way as in net/http/request.go).
 func validMethod(method string) bool {
 	return len(method) > 0 && strings.IndexFunc(method, isNotToken) == -1
 }
 
 //isNotToken is copied from net/http/http.go
-//its is used by validMethod to validate X-HTTP-Method-Override
+// used by validMethod to detect unacceptable characters in X-HTTP-Method-Override
 func isNotToken(r rune) bool {
 	return !httpguts.IsTokenRune(r)
 }

--- a/router.go
+++ b/router.go
@@ -162,11 +162,13 @@ func treePath(method, path string) string {
 }
 
 //validMethod is copied from net/http/request.go
+//its used to validate the X-HTTP-Method-Override so that it only may contain valid characters for a http method in a identical way to how net/http validates method.
 func validMethod(method string) bool {
 	return len(method) > 0 && strings.IndexFunc(method, isNotToken) == -1
 }
 
 //isNotToken is copied from net/http/http.go
+//its is used by validMethod to validate X-HTTP-Method-Override
 func isNotToken(r rune) bool {
 	return !httpguts.IsTokenRune(r)
 }
@@ -179,7 +181,7 @@ type Router struct {
 }
 
 func (router *Router) Route(req *Request) (routeMatch *RouteMatch) {
-	// Override method if set in header
+	// Override method if set in header and content is a valid method
 	if method := req.GetHttpHeader("X-HTTP-Method-Override"); method != "" && req.Method == "POST" && validMethod(method) {
 		req.Method = method
 	}

--- a/router.go
+++ b/router.go
@@ -182,6 +182,7 @@ type Router struct {
 
 func (router *Router) Route(req *Request) (routeMatch *RouteMatch) {
 	// Override method if set in header and content is a valid method
+	// It's important to verify that the override method is a valid method before using it. This is because revels internal routing key is based on the concatenation of method and path. If / would be allowed in the override method then it would be possible to modify the path portion of the routing key which we don't want.
 	if method := req.GetHttpHeader("X-HTTP-Method-Override"); method != "" && req.Method == "POST" && validMethod(method) {
 		req.Method = method
 	}


### PR DESCRIPTION
Verify that the method in X-HTTP-Method-Override is a valid method
before use using it. Validation is performed using the same logic
as net/http dose. This prevents a routing confusion vulnerability
that allowed an attacker to control the entire internal revel routing
path (used to find a controller) via the override header. This issue can
be problematic in instances where authentication is based on the path
for example in a revel.Filter or if the revel app is behind a reverse
proxy.