### PR TITLE
Escaping filename in Content-Disposition

### DIFF
--- a/results.go
+++ b/results.go
@@ -397,7 +397,10 @@ func (r *BinaryResult) Apply(req *Request, resp *Response) {
 	if r.Delivery != NoDisposition {
 		disposition := string(r.Delivery)
 		if r.Name != "" {
-			disposition += fmt.Sprintf(`; filename="%s"`, r.Name)
+			disposition += fmt.Sprintf(
+				`; filename="%s"`,
+				strings.Replace(r.Name, "\"", "\\\"", -1),
+			)
 		}
 		resp.Out.internalHeader.Set("Content-Disposition", disposition)
 	}


### PR DESCRIPTION
The filename returned by `RenderFileName` does not escape the `"` character.
This PR suppresses incorrect behavior when downloading files with special file names.

Details were sent to @brendensoares, @notzippy on gitter.