### PR TITLE
Add pre-configured languages for timeago

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/revel/log15 v2.11.20+incompatible
 	github.com/revel/pathtree v0.0.0-20140121041023-41257a1839e9
 	github.com/stretchr/testify v1.7.1
-	github.com/xeonx/timeago v1.0.0-rc4
+	github.com/xeonx/timeago v1.0.0-rc5
 	golang.org/x/net v0.0.0-20220412020605-290c469a71a5
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/stack.v0 v0.0.0-20141108040640-9b43fcefddd0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/xeonx/timeago v1.0.0-rc4 h1:9rRzv48GlJC0vm+iBpLcWAr8YbETyN9Vij+7h2ammz4=
 github.com/xeonx/timeago v1.0.0-rc4/go.mod h1:qDLrYEFynLO7y5Ho7w3GwgtYgpy5UfhcXIIQvMKVDkA=
+github.com/xeonx/timeago v1.0.0-rc5 h1:pwcQGpaH3eLfPtXeyPA4DmHWjoQt0Ea7/++FwpxqLxg=
+github.com/xeonx/timeago v1.0.0-rc5/go.mod h1:qDLrYEFynLO7y5Ho7w3GwgtYgpy5UfhcXIIQvMKVDkA=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5 h1:bRb386wvrE+oBNdF1d/Xh9mQrfQ4ecYhW5qJ5GvTGT4=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/template_functions.go
+++ b/template_functions.go
@@ -313,10 +313,26 @@ func TimeAgo(args ...interface{}) string {
 
 	if lang == "" {
 		lang, _ = Config.String(defaultLanguageOption)
-		if lang == "en" {
-			timeAgoLangs[lang] = timeago.English
-		}
 	}
+	switch lang {
+	case "de":
+		timeAgoLangs[lang] = timeago.German
+	case "fr":
+		timeAgoLangs[lang] = timeago.French
+	case "ko":
+		timeAgoLangs[lang] = timeago.Korean
+	case "pt":
+		timeAgoLangs[lang] = timeago.Portuguese
+	case "sp":
+		timeAgoLangs[lang] = timeago.Spanish
+	case "tr":
+		timeAgoLangs[lang] = timeago.Turkish
+	case "zh":
+		timeAgoLangs[lang] = timeago.Chinese
+	default:
+		timeAgoLangs[lang] = timeago.English
+	}
+	
 
 	_, ok := timeAgoLangs[lang]
 	if !ok {


### PR DESCRIPTION
Allow use of pre-configured translation available in timeago code from i18n.default_language in config, otherwise fall back in former behavior using i18n.

require version 1.0.0.rc5 for Spanish

See also https://github.com/revel/revel.github.io/pull/212 for documentation