### PR TITLE
Fix: Eliminates deprecated ioutil

### DIFF
--- a/binder.go
+++ b/binder.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"os"
 	"reflect"
@@ -380,7 +379,7 @@ func bindFile(params *Params, name string, typ reflect.Type) reflect.Value {
 	}
 
 	// Otherwise, have to store it.
-	tmpFile, err := ioutil.TempFile("", "revel-upload")
+	tmpFile, err := os.CreateTemp("", "revel-upload")
 	if err != nil {
 		binderLog.Warn("bindFile: Failed to create a temp file to store upload", "name", name, "error", err)
 		return reflect.Zero(typ)
@@ -406,7 +405,7 @@ func bindFile(params *Params, name string, typ reflect.Type) reflect.Value {
 
 func bindByteArray(params *Params, name string, typ reflect.Type) reflect.Value {
 	if reader := getMultipartFile(params, name); reader != nil {
-		b, err := ioutil.ReadAll(reader)
+		b, err := io.ReadAll(reader)
 		if err == nil {
 			return reflect.ValueOf(b)
 		}
@@ -423,7 +422,8 @@ func bindReadSeeker(params *Params, name string, typ reflect.Type) reflect.Value
 }
 
 // bindMap converts parameters using map syntax into the corresponding map. e.g.:
-//   params["a[5]"]=foo, name="a", typ=map[int]string => map[int]string{5: "foo"}
+//
+//	params["a[5]"]=foo, name="a", typ=map[int]string => map[int]string{5: "foo"}
 func bindMap(params *Params, name string, typ reflect.Type) reflect.Value {
 	var (
 		keyType   = typ.Key()

--- a/binder_test.go
+++ b/binder_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -180,10 +179,10 @@ var binderTestCases = map[string]interface{}{
 // that type.
 // TODO: Is there any way to create a slice, given only the element Type?
 var fileBindings = []struct{ val, arrval, f interface{} }{
-	{(**os.File)(nil), []*os.File{}, ioutil.ReadAll},
+	{(**os.File)(nil), []*os.File{}, io.ReadAll},
 	{(*[]byte)(nil), [][]byte{}, func(b []byte) []byte { return b }},
-	{(*io.Reader)(nil), []io.Reader{}, ioutil.ReadAll},
-	{(*io.ReadSeeker)(nil), []io.ReadSeeker{}, ioutil.ReadAll},
+	{(*io.Reader)(nil), []io.Reader{}, io.ReadAll},
+	{(*io.ReadSeeker)(nil), []io.ReadSeeker{}, io.ReadAll},
 }
 
 func TestJsonBinder(t *testing.T) {

--- a/params.go
+++ b/params.go
@@ -7,7 +7,7 @@ package revel
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/url"
 	"os"
@@ -64,7 +64,7 @@ func ParseParams(params *Params, req *Request) {
 		fallthrough
 	case "text/json":
 		if body := req.GetBody(); body != nil {
-			if content, err := ioutil.ReadAll(body); err == nil {
+			if content, err := io.ReadAll(body); err == nil {
 				// We wont bind it until we determine what we are binding too
 				params.JSON = content
 			} else {

--- a/params_test.go
+++ b/params_test.go
@@ -7,7 +7,7 @@ package revel
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -112,7 +112,7 @@ func TestMultipartForm(t *testing.T) {
 	for key, fileHeaders := range c.Params.Files {
 		for _, fileHeader := range fileHeaders {
 			file, _ := fileHeader.Open()
-			content, _ := ioutil.ReadAll(file)
+			content, _ := io.ReadAll(file)
 			actualFiles[key] = append(actualFiles[key], fh{fileHeader.Filename, content})
 		}
 	}

--- a/results.go
+++ b/results.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -152,7 +151,7 @@ func (r *RenderTemplateResult) Apply(req *Request, resp *Response) {
 	// If it's a HEAD request, throw away the bytes.
 	out := resp.GetWriter()
 	if req.Method == "HEAD" {
-		out = ioutil.Discard
+		out = io.Discard
 	}
 
 	// In a prod mode, write the status, render, and hope for the best.

--- a/router.go
+++ b/router.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/revel/pathtree"
+
 	"github.com/revel/revel/logger"
 )
 
@@ -429,7 +429,7 @@ func splitActionPath(actionPathData *ActionPathData, actionPath string, useCache
 
 // parseRoutesFile reads the given routes file and returns the contained routes.
 func parseRoutesFile(moduleSource *Module, routesPath, joinedPath string, validate bool) ([]*Route, *Error) {
-	contentBytes, err := ioutil.ReadFile(routesPath)
+	contentBytes, err := os.ReadFile(routesPath)
 	if err != nil {
 		return nil, &Error{
 			Title:       "Failed to load routes file",
@@ -540,7 +540,7 @@ func routeError(err error, routesPath, content string, n int) *Error {
 	}
 	// Load the route file content if necessary
 	if content == "" {
-		if contentBytes, er := ioutil.ReadFile(routesPath); er != nil {
+		if contentBytes, er := os.ReadFile(routesPath); er != nil {
 			routerLog.Error("routeError: Failed to read route file ", "file", routesPath, "error", er)
 		} else {
 			content = string(contentBytes)

--- a/template.go
+++ b/template.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -273,7 +272,7 @@ func (runtimeLoader *templateRuntime) findAndAddTemplate(path, fullSrcDir, baseP
 		return
 	}
 
-	fileBytes, err = ioutil.ReadFile(path)
+	fileBytes, err = os.ReadFile(path)
 	if err != nil {
 		templateLog.Error("findAndAddTemplate: Failed reading file:", "path", path, "error", err)
 		return

--- a/testing/testsuite.go
+++ b/testing/testsuite.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -62,6 +61,7 @@ func NewTestSuiteEngine(engine revel.SessionEngine) TestSuite {
 
 // NewTestRequest returns an initialized *TestRequest. It is used for extending
 // testsuite package making it possible to define own methods. Example:
+//
 //	type MyTestSuite struct {
 //		testing.TestSuite
 //	}
@@ -266,7 +266,7 @@ func (r *TestRequest) MakeRequest() {
 	if r.testSuite.Response, err = r.testSuite.Client.Do(r.Request); err != nil {
 		panic(err)
 	}
-	if r.testSuite.ResponseBody, err = ioutil.ReadAll(r.testSuite.Response.Body); err != nil {
+	if r.testSuite.ResponseBody, err = io.ReadAll(r.testSuite.Response.Body); err != nil {
 		panic(err)
 	}
 

--- a/util.go
+++ b/util.go
@@ -7,7 +7,6 @@ package revel
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -58,7 +57,7 @@ func MustReadLines(filename string) []string {
 
 // ReadLines reads the lines of the given file.  Panics in the case of error.
 func ReadLines(filename string) ([]string, error) {
-	dataBytes, err := ioutil.ReadFile(filename)
+	dataBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +143,11 @@ func FirstNonEmpty(strs ...string) string {
 }
 
 // Equal is a helper for comparing value equality, following these rules:
-//  - Values with equivalent types are compared with reflect.DeepEqual
-//  - int, uint, and float values are compared without regard to the type width.
-//    for example, Equal(int32(5), int64(5)) == true
-//  - strings and byte slices are converted to strings before comparison.
-//  - else, return false.
+//   - Values with equivalent types are compared with reflect.DeepEqual
+//   - int, uint, and float values are compared without regard to the type width.
+//     for example, Equal(int32(5), int64(5)) == true
+//   - strings and byte slices are converted to strings before comparison.
+//   - else, return false.
 func Equal(a, b interface{}) bool {
 	if reflect.TypeOf(a) == reflect.TypeOf(b) {
 		return reflect.DeepEqual(a, b)


### PR DESCRIPTION
In Go, "io/ioutil" is now deprecated in favor of the drop in replacements "io" and "os" The changes in this code eliminate ioutil and substitute functions like ioutil.Tempfile with os.CreateTemp, ioutil.ReadAll with io.ReadAll and ioutil.Discard with io.Discard in source and tests.

Happy Hacktoberfest, thank you for reviewing my PR :)